### PR TITLE
backend: LambdaのOpenSSL依存不足を解消

### DIFF
--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -27,18 +27,21 @@ jobs:
           # Backend/Dockerfile を使ってルートをコンテキストにビルド
           docker build -t matoolapi -f Backend/Dockerfile .
 
-          # イメージから bootstrap を抽出（Lambda用の最小実行ファイル名が bootstrap の場合）
+          # イメージから Lambda 配布物一式を抽出
           docker create --name extract matoolapi
-          docker cp extract:/var/runtime/bootstrap ./bootstrap || true
+          mkdir -p lambda-dist
+          docker cp extract:/var/task/. ./lambda-dist
           docker rm extract || true
 
-          # 如果 bootstrap が PATH にない場合や、別の場所にあるなら Dockerfile 側で配置を合わせてください
-          if [ -f ./bootstrap ]; then
-            chmod +x ./bootstrap
-            zip -r lambda.zip bootstrap
+          if [ -f ./lambda-dist/bootstrap ]; then
+            chmod +x ./lambda-dist/bootstrap ./lambda-dist/MaToolAPI
+            (
+              cd lambda-dist
+              zip -r ../lambda.zip .
+            )
             ls -l lambda.zip
           else
-            echo "Error: bootstrap not found in image. Inspect Dockerfile and image layout."
+            echo "Error: Lambda package not found in image. Inspect Dockerfile and image layout."
             exit 1
           fi
 

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -49,14 +49,22 @@ RUN strip .build/release/Backend
 
 RUN ls -lh .build/release/Backend
 
+# Lambda zip 配布用にバイナリと依存共有ライブラリを同梱
+RUN mkdir -p /workspace/lambda/lib && \
+    cp .build/release/Backend /workspace/lambda/MaToolAPI && \
+    cp scripts/bootstrap /workspace/lambda/bootstrap && \
+    chmod +x /workspace/lambda/bootstrap /workspace/lambda/MaToolAPI && \
+    ldd .build/release/Backend | awk '/=> \// { print $3 } /^\// { print $1 }' | sort -u | \
+      xargs -I '{}' cp '{}' /workspace/lambda/lib/
+
 # ============================
 # Stage 2: Lambda Runtime (AL2023)
 # ============================
 FROM public.ecr.aws/lambda/provided:al2023
 
-# ビルド済みバイナリをコピー
-COPY --from=build /workspace/Backend/.build/release/Backend /var/runtime/bootstrap
+# Lambda 配布物一式をコピー
+COPY --from=build /workspace/lambda /var/task
 
-RUN chmod +x /var/runtime/bootstrap
+RUN chmod +x /var/task/bootstrap /var/task/MaToolAPI
 
-ENTRYPOINT ["/var/runtime/bootstrap"]
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Backend/scripts/bootstrap
+++ b/Backend/scripts/bootstrap
@@ -3,12 +3,18 @@
 # このスクリプトは Lambda がコンテナ内で実行するときに呼ばれます。
 # 単にビルドしたバイナリを実行するだけのシンプル実装。
 
-# 同じディレクトリに MaToolAPI バイナリがある想定
-BIN="./MaToolAPI"
+# 同じディレクトリに MaToolAPI バイナリと共有ライブラリがある想定
+TASK_ROOT="${LAMBDA_TASK_ROOT:-$(dirname "$0")}"
+BIN="$TASK_ROOT/MaToolAPI"
+LIB_DIR="$TASK_ROOT/lib"
 
 if [ ! -x "$BIN" ]; then
   echo "ERROR: binary not found or not executable: $BIN" >&2
   exit 1
+fi
+
+if [ -d "$LIB_DIR" ]; then
+  export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 fi
 
 # exec で置き換える（プロセス継承）


### PR DESCRIPTION
Lambda Runtime.ExitError (OPENSSL_3.4.0 not found) 対応。Deploy workflowで/var/task配下を丸ごとzip化し、DockerfileでMaToolAPIと依存共有ライブラリを同梱、bootstrapでLD_LIBRARY_PATHを設定して起動するよう修正。