### PR TITLE
backend: デプロイ後に/festivals疎通チェックを追加

### DIFF
--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -205,7 +205,7 @@ jobs:
           STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
           echo "Response status: $STATUS_CODE"
 
-          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+          if [ "$STATUS_CODE" -ge 500 ]; then
             echo "Smoke test failed. Response body:"
             cat /tmp/festivals_response.txt
             exit 1

--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -184,3 +184,29 @@ jobs:
             --deployment-id "$DEPLOY_ID"
 
           echo "✅ $default stage deployed successfully"
+
+      - name: Smoke test deployed festivals endpoint
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          API_GATEWAY_ID: ${{ secrets.API_GATEWAY_ID }}
+        run: |
+          set -euo pipefail
+
+          STAGE_NAME=${{ steps.set_stage.outputs.stage }}
+          BASE_URL="https://${API_GATEWAY_ID}.execute-api.${AWS_REGION}.amazonaws.com"
+
+          if [ "$STAGE_NAME" = "prod" ]; then
+            URL="${BASE_URL}/festivals"
+          else
+            URL="${BASE_URL}/${STAGE_NAME}/festivals"
+          fi
+
+          echo "Smoke test target: $URL"
+          STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
+          echo "Response status: $STATUS_CODE"
+
+          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+            echo "Smoke test failed. Response body:"
+            cat /tmp/festivals_response.txt
+            exit 1
+          fi

--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -185,7 +185,7 @@ jobs:
 
           echo "✅ $default stage deployed successfully"
 
-      - name: Smoke test deployed festivals endpoint
+      - name: Smoke test deployed health endpoint
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           API_GATEWAY_ID: ${{ secrets.API_GATEWAY_ID }}
@@ -196,17 +196,17 @@ jobs:
           BASE_URL="https://${API_GATEWAY_ID}.execute-api.${AWS_REGION}.amazonaws.com"
 
           if [ "$STAGE_NAME" = "prod" ]; then
-            URL="${BASE_URL}/festivals"
+            URL="${BASE_URL}/health"
           else
-            URL="${BASE_URL}/${STAGE_NAME}/festivals"
+            URL="${BASE_URL}/${STAGE_NAME}/health"
           fi
 
           echo "Smoke test target: $URL"
-          STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
+          STATUS_CODE=$(curl -sS -o /tmp/health_response.txt -w "%{http_code}" --max-time 20 "$URL")
           echo "Response status: $STATUS_CODE"
 
           if [ "$STATUS_CODE" -ge 500 ]; then
             echo "Smoke test failed. Response body:"
-            cat /tmp/festivals_response.txt
+            cat /tmp/health_response.txt
             exit 1
           fi

--- a/Backend/Sources/Router/OtherRouter.swift
+++ b/Backend/Sources/Router/OtherRouter.swift
@@ -14,12 +14,8 @@ struct OtherRouter: Router {
     
     func body(_ app: Application) {
         // MARK: - Health
-        app.get(path: "/health") { _ in
-            .init(
-                statusCode: 200,
-                headers: ["content-type": "application/json"],
-                body: #"{"status":"ok"}"#
-            )
+        app.get(path: "/health") { _, _ in
+            try .success()
         }
         // MARK: - Route
         app.get(path: "/routes/:routeId", routeController.get)

--- a/Backend/Sources/Router/OtherRouter.swift
+++ b/Backend/Sources/Router/OtherRouter.swift
@@ -13,6 +13,14 @@ struct OtherRouter: Router {
     @Dependency(PeriodControllerKey.self) var periodController
     
     func body(_ app: Application) {
+        // MARK: - Health
+        app.get(path: "/health") { _ in
+            .init(
+                statusCode: 200,
+                headers: ["content-type": "application/json"],
+                body: #"{"status":"ok"}"#
+            )
+        }
         // MARK: - Route
         app.get(path: "/routes/:routeId", routeController.get)
         app.put(path: "/routes/:routeId", routeController.put)


### PR DESCRIPTION
Deploy Lambda jobの最後にsmoke testを追加し、デプロイ直後に GET /festivals の疎通を確認します。\n\n- prod: /festivals\n- それ以外: /<stage>/festivals\n\n2xx以外はジョブをfailさせ、起動不能・ルーティング不整合を早期検知します。