### PR TITLE
backend: #247/#248 の欠落分を復元

### DIFF
--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -205,7 +205,7 @@ jobs:
           STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
           echo "Response status: $STATUS_CODE"
 
-          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+          if [ "$STATUS_CODE" -ge 500 ]; then
             echo "Smoke test failed. Response body:"
             cat /tmp/festivals_response.txt
             exit 1

--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -184,3 +184,29 @@ jobs:
             --deployment-id "$DEPLOY_ID"
 
           echo "✅ $default stage deployed successfully"
+
+      - name: Smoke test deployed festivals endpoint
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          API_GATEWAY_ID: ${{ secrets.API_GATEWAY_ID }}
+        run: |
+          set -euo pipefail
+
+          STAGE_NAME=${{ steps.set_stage.outputs.stage }}
+          BASE_URL="https://${API_GATEWAY_ID}.execute-api.${AWS_REGION}.amazonaws.com"
+
+          if [ "$STAGE_NAME" = "prod" ]; then
+            URL="${BASE_URL}/festivals"
+          else
+            URL="${BASE_URL}/${STAGE_NAME}/festivals"
+          fi
+
+          echo "Smoke test target: $URL"
+          STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
+          echo "Response status: $STATUS_CODE"
+
+          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+            echo "Smoke test failed. Response body:"
+            cat /tmp/festivals_response.txt
+            exit 1
+          fi

--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -27,18 +27,21 @@ jobs:
           # Backend/Dockerfile を使ってルートをコンテキストにビルド
           docker build -t matoolapi -f Backend/Dockerfile .
 
-          # イメージから bootstrap を抽出（Lambda用の最小実行ファイル名が bootstrap の場合）
+          # イメージから Lambda 配布物一式を抽出
           docker create --name extract matoolapi
-          docker cp extract:/var/runtime/bootstrap ./bootstrap || true
+          mkdir -p lambda-dist
+          docker cp extract:/var/task/. ./lambda-dist
           docker rm extract || true
 
-          # 如果 bootstrap が PATH にない場合や、別の場所にあるなら Dockerfile 側で配置を合わせてください
-          if [ -f ./bootstrap ]; then
-            chmod +x ./bootstrap
-            zip -r lambda.zip bootstrap
+          if [ -f ./lambda-dist/bootstrap ]; then
+            chmod +x ./lambda-dist/bootstrap ./lambda-dist/MaToolAPI
+            (
+              cd lambda-dist
+              zip -r ../lambda.zip .
+            )
             ls -l lambda.zip
           else
-            echo "Error: bootstrap not found in image. Inspect Dockerfile and image layout."
+            echo "Error: Lambda package not found in image. Inspect Dockerfile and image layout."
             exit 1
           fi
 

--- a/.github/workflows/job_deploy_backend.yml
+++ b/.github/workflows/job_deploy_backend.yml
@@ -185,7 +185,7 @@ jobs:
 
           echo "✅ $default stage deployed successfully"
 
-      - name: Smoke test deployed festivals endpoint
+      - name: Smoke test deployed health endpoint
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           API_GATEWAY_ID: ${{ secrets.API_GATEWAY_ID }}
@@ -196,17 +196,17 @@ jobs:
           BASE_URL="https://${API_GATEWAY_ID}.execute-api.${AWS_REGION}.amazonaws.com"
 
           if [ "$STAGE_NAME" = "prod" ]; then
-            URL="${BASE_URL}/festivals"
+            URL="${BASE_URL}/health"
           else
-            URL="${BASE_URL}/${STAGE_NAME}/festivals"
+            URL="${BASE_URL}/${STAGE_NAME}/health"
           fi
 
           echo "Smoke test target: $URL"
-          STATUS_CODE=$(curl -sS -o /tmp/festivals_response.txt -w "%{http_code}" --max-time 20 "$URL")
+          STATUS_CODE=$(curl -sS -o /tmp/health_response.txt -w "%{http_code}" --max-time 20 "$URL")
           echo "Response status: $STATUS_CODE"
 
           if [ "$STATUS_CODE" -ge 500 ]; then
             echo "Smoke test failed. Response body:"
-            cat /tmp/festivals_response.txt
+            cat /tmp/health_response.txt
             exit 1
           fi

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -49,14 +49,22 @@ RUN strip .build/release/Backend
 
 RUN ls -lh .build/release/Backend
 
+# Lambda zip 配布用にバイナリと依存共有ライブラリを同梱
+RUN mkdir -p /workspace/lambda/lib && \
+    cp .build/release/Backend /workspace/lambda/MaToolAPI && \
+    cp scripts/bootstrap /workspace/lambda/bootstrap && \
+    chmod +x /workspace/lambda/bootstrap /workspace/lambda/MaToolAPI && \
+    ldd .build/release/Backend | awk '/=> \// { print $3 } /^\// { print $1 }' | sort -u | \
+      xargs -I '{}' cp '{}' /workspace/lambda/lib/
+
 # ============================
 # Stage 2: Lambda Runtime (AL2023)
 # ============================
 FROM public.ecr.aws/lambda/provided:al2023
 
-# ビルド済みバイナリをコピー
-COPY --from=build /workspace/Backend/.build/release/Backend /var/runtime/bootstrap
+# Lambda 配布物一式をコピー
+COPY --from=build /workspace/lambda /var/task
 
-RUN chmod +x /var/runtime/bootstrap
+RUN chmod +x /var/task/bootstrap /var/task/MaToolAPI
 
-ENTRYPOINT ["/var/runtime/bootstrap"]
+ENTRYPOINT ["/var/task/bootstrap"]

--- a/Backend/Sources/Router/OtherRouter.swift
+++ b/Backend/Sources/Router/OtherRouter.swift
@@ -14,12 +14,8 @@ struct OtherRouter: Router {
     
     func body(_ app: Application) {
         // MARK: - Health
-        app.get(path: "/health") { _ in
-            .init(
-                statusCode: 200,
-                headers: ["content-type": "application/json"],
-                body: #"{"status":"ok"}"#
-            )
+        app.get(path: "/health") { _, _ in
+            try .success()
         }
         // MARK: - Route
         app.get(path: "/routes/:routeId", routeController.get)

--- a/Backend/Sources/Router/OtherRouter.swift
+++ b/Backend/Sources/Router/OtherRouter.swift
@@ -13,6 +13,14 @@ struct OtherRouter: Router {
     @Dependency(PeriodControllerKey.self) var periodController
     
     func body(_ app: Application) {
+        // MARK: - Health
+        app.get(path: "/health") { _ in
+            .init(
+                statusCode: 200,
+                headers: ["content-type": "application/json"],
+                body: #"{"status":"ok"}"#
+            )
+        }
         // MARK: - Route
         app.get(path: "/routes/:routeId", routeController.get)
         app.put(path: "/routes/:routeId", routeController.put)

--- a/Backend/scripts/bootstrap
+++ b/Backend/scripts/bootstrap
@@ -3,12 +3,18 @@
 # このスクリプトは Lambda がコンテナ内で実行するときに呼ばれます。
 # 単にビルドしたバイナリを実行するだけのシンプル実装。
 
-# 同じディレクトリに MaToolAPI バイナリがある想定
-BIN="./MaToolAPI"
+# 同じディレクトリに MaToolAPI バイナリと共有ライブラリがある想定
+TASK_ROOT="${LAMBDA_TASK_ROOT:-$(dirname "$0")}"
+BIN="$TASK_ROOT/MaToolAPI"
+LIB_DIR="$TASK_ROOT/lib"
 
 if [ ! -x "$BIN" ]; then
   echo "ERROR: binary not found or not executable: $BIN" >&2
   exit 1
+fi
+
+if [ -d "$LIB_DIR" ]; then
+  export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 fi
 
 # exec で置き換える（プロセス継承）


### PR DESCRIPTION
## 目的
環境変数混入対応の上書き時に欠落した可能性がある #247/#248 の backend 変更を main に復元する。

## 変更点
- #247 の変更を復元
  - Lambda配布物に共有ライブラリを同梱
- #248 の変更を復元
  - deploy後の /festivals 疎通チェック
  - smoke test を 5xx 失敗限定
  - 起動確認用 /health エンドポイント追加と型不一致修正

## 動作確認
- cherry-pick 適用が衝突なく完了
- 変更差分が backend/workflow のみであることを確認

## 補足
- 復元のためコミットハッシュは元PRと異なる（内容は同等）