### PR TITLE
backend: District作成のCognito再試行耐性を追加

### DIFF
--- a/Backend/Sources/Usecase/DistrictUsecase.swift
+++ b/Backend/Sources/Usecase/DistrictUsecase.swift
@@ -64,10 +64,20 @@ struct DistrictUsecase: DistrictUsecaseProtocol {
         }
 
         // 招待処理
-        let _ = try await managerFactory().create(
-            username: districtId,
-            email: email
-        )
+        // Lambda retry で create が UsernameExists になるケースでは、
+        // 既存ユーザーが district と確認できれば続行する。
+        let manager = try await managerFactory()
+        do {
+            let _ = try await manager.create(
+                username: districtId,
+                email: email
+            )
+        } catch {
+            let existing = try? await manager.get(username: districtId)
+            guard case .district(districtId)? = existing else {
+                throw error
+            }
+        }
 
         // District生成
         let item = District(

--- a/Backend/Tests/Usecase/DistrictUsecaseTest.swift
+++ b/Backend/Tests/Usecase/DistrictUsecaseTest.swift
@@ -107,6 +107,44 @@ struct DistrictUsecaseTest {
     }
 
     @Test
+    func post_正常_create失敗でも既存districtユーザーなら継続() async throws {
+        let festival = Festival.mock(id: "festival_2026")
+        let expectedDistrictId = "festival_new"
+        enum DummyError: Swift.Error { case failed }
+
+        let manager = AuthManagerMock(
+            createHandler: { _, _ in throw DummyError.failed },
+            getUserNameHandler: { username in
+                #expect(username == expectedDistrictId)
+                return .district(username)
+            }
+        )
+
+        let subject = make(
+            districtRepository: .init(
+                getHandler: { id in
+                    if id == expectedDistrictId { return nil }
+                    return nil
+                },
+                postHandler: { $0 }
+            ),
+            festivalRepository: .init(getHandler: { _ in festival }),
+            authManagerFactory: { manager }
+        )
+
+        let result = try await subject.post(
+            user: .headquarter(festival.id),
+            headquarterId: festival.id,
+            newDistrictName: "new",
+            email: "district@example.com"
+        )
+
+        #expect(manager.createCallCount == 1)
+        #expect(manager.getUserNameCallCount == 1)
+        #expect(result.district.id == expectedDistrictId)
+    }
+
+    @Test
     func postReissue_正常() async throws {
         let festival = Festival.mock(id: "festival_2026")
         let districtId = "festival_new"


### PR DESCRIPTION
## 目的
District作成APIで、Lambda再試行時にCognito createの失敗が起点になって処理全体が失敗するケースを緩和する。

## 変更点
-  の招待処理を  化
-  が失敗した場合、 で既存ユーザーを確認
- 既存ユーザーが  なら継続し、そうでなければ元エラーをthrow
- 上記挙動のユニットテストを追加

## 動作確認
-  を実行
- 実行環境制約により xcodebuild が失敗（ / CoreSimulator接続エラー）
- 追加したユニットテストはローカル論理上でコンパイル可能な形に合わせている

## 影響範囲
- Backend  のCognito失敗時分岐のみ
-  はこのPRでは未変更