### PR TITLE
ios: Checkpoint編集で削除ボタンを常時表示

### DIFF
--- a/iOSApp/Sources/Presentation/View/Admin/Region/Edit/CheckpointEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Edit/CheckpointEditFeature.swift
@@ -22,6 +22,7 @@ struct CheckpointEditFeature {
         case binding(BindingAction<State>)
         case cancelTapped
         case doneTapped
+        case deleteTapped
     }
     
     @Dependency(\.dismiss) var dismiss
@@ -35,6 +36,8 @@ struct CheckpointEditFeature {
             case .cancelTapped:
                 return .dismiss
             case .doneTapped:
+                return .none
+            case .deleteTapped:
                 return .none
             }
         }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Edit/CheckpointEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Edit/CheckpointEditView.swift
@@ -23,6 +23,12 @@ struct CheckpointEditView: View {
                 TextEditor(text: $store.item.description.nonOptional)
                     .frame(height:60)
             }
+            Section {
+                Button("削除", systemImage: "trash", role: .destructive) {
+                    store.send(.deleteTapped)
+                }
+                .foregroundStyle(.red)
+            }
         }
         .navigationTitle(store.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Edit/FestivalEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Edit/FestivalEditFeature.swift
@@ -126,6 +126,11 @@ struct FestivalEditFeature {
                 state.checkpoints.upsert(item)
                 state.destination = nil
                 return .none
+            case .destination(.presented(.checkpoint(.deleteTapped))):
+                guard let item = state.destination?.checkpoint?.item else { return .none }
+                state.checkpoints.removeAll(of: item)
+                state.destination = nil
+                return .none
             case .destination(.presented(.hazard(.doneTapped))):
                 guard state.destination?.hazard?.isValid ?? false,
                     let item = state.destination?.hazard?.item else { return .none }


### PR DESCRIPTION
## 目的
Checkpoint編集画面で、編集モード時にも削除ボタンを表示して削除できるようにするため。

## 変更点
- `CheckpointEditView` に削除ボタンを追加（表示条件なしで常時表示）
- `CheckpointEditFeature` に `deleteTapped` アクションを追加
- `FestivalEditFeature` で `checkpoint.deleteTapped` を受け取り、対象チェックポイントを削除して編集画面を閉じる処理を追加

## 動作確認
- `git diff main...HEAD` で差分を確認
- `safe_build_test.sh ios-run` 実行: 失敗（利用可能なiOS Simulatorが見つからない）
- `safe_build_test.sh ios-build` 実行: 失敗（CoreSimulator接続不可、および `MaTool.xcworkspace` 解決エラー）

## 影響範囲・リスク
- 影響範囲はCheckpoint編集画面とその親の保存前状態管理のみ
- 実機/SimulatorでのUI挙動はこの環境制約により未確認
