### PR TITLE
AppErrorに統一してTaskResultを廃止

### DIFF
--- a/iOSApp/MaTool.xcodeproj/project.pbxproj
+++ b/iOSApp/MaTool.xcodeproj/project.pbxproj
@@ -635,16 +635,20 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.25.2;
+				minimumVersion = 1.26.0;
 			};
+			traits = (
+			);
 		};
 		29CC9E402F1523B800C4CD50 /* XCRemoteSwiftPackageReference "sqlite-data" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/sqlite-data.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.3;
+				minimumVersion = 1.6.6;
 			};
+			traits = (
+			);
 		};
 		29F7B72D2EC871F10099607E /* XCRemoteSwiftPackageReference "amplify-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;

--- a/iOSApp/Sources/Application/AuthService.swift
+++ b/iOSApp/Sources/Application/AuthService.swift
@@ -46,9 +46,7 @@ struct AuthService: AuthServiceProtocol {
     
     func signIn(_ username: String, password: String) async throws -> SignInState {
         try? await authProvider.signOut()
-        print("signOut")
         let result = try await authProvider.signIn(username, password)
-        print("signIn")
         switch result {
         case .newPasswordRequired:
             return .newPasswordRequired

--- a/iOSApp/Sources/Application/AuthService.swift
+++ b/iOSApp/Sources/Application/AuthService.swift
@@ -46,7 +46,9 @@ struct AuthService: AuthServiceProtocol {
     
     func signIn(_ username: String, password: String) async throws -> SignInState {
         try? await authProvider.signOut()
+        print("signOut")
         let result = try await authProvider.signIn(username, password)
+        print("signIn")
         switch result {
         case .newPasswordRequired:
             return .newPasswordRequired

--- a/iOSApp/Sources/Application/LocationService.swift
+++ b/iOSApp/Sources/Application/LocationService.swift
@@ -141,10 +141,10 @@ actor LocationService: LocationServiceProtocol {
             do {
                 try await dataFetcher.update(location)
                 appendHistory(.update(location))
-            } catch let error as APIError {
+            } catch let error as AppError {
                 appendHistory(.apiError(Date(), error))
             } catch {
-                appendHistory(.apiError(Date(), .unknown(message: error.localizedDescription)))
+                appendHistory(.apiError(Date(), error.asAppError))
             }
         }
     }
@@ -153,10 +153,10 @@ actor LocationService: LocationServiceProtocol {
         do {
             try await dataFetcher.delete(districtId: id)
             appendHistory(.delete(Date()))
-        } catch let error as APIError {
+        } catch let error as AppError {
             appendHistory(.apiError(Date(), error))
         } catch {
-            appendHistory(.apiError(Date(), .unknown(message: error.localizedDescription)))
+            appendHistory(.apiError(Date(), error.asAppError))
         }
     }
     

--- a/iOSApp/Sources/Application/SceneUsecase.swift
+++ b/iOSApp/Sources/Application/SceneUsecase.swift
@@ -85,7 +85,9 @@ actor SceneUsecase: SceneUsecaseProtocol {
     }
     
     func signIn(username: String, password: String) async throws -> SignInState {
+        print("Usecase start")
         let signInResult = try await authService.signIn(username, password: password)
+        print("Usecase signIn")
         if case .signedIn(.headquarter(let festivalId)) = signInResult {
             try await dataFetcher.launchFestival(festivalId: festivalId)
             userDefaults.defaultDistrictId = nil

--- a/iOSApp/Sources/Application/SceneUsecase.swift
+++ b/iOSApp/Sources/Application/SceneUsecase.swift
@@ -77,10 +77,10 @@ actor SceneUsecase: SceneUsecaseProtocol {
                     try await festivalDataFetcher.fetchAll()
                     return (.onboarding, await appStatusTask)
                 } catch {
-                    return (.error(error.localizedDescription), await appStatusTask)
+                    return (.error(error.asAppError.message), await appStatusTask)
                 }
             }
-            return (.error(error.localizedDescription), await appStatusTask)
+            return (.error(error.asAppError.message), await appStatusTask)
         }
     }
     
@@ -139,7 +139,7 @@ actor SceneUsecase: SceneUsecaseProtocol {
     
     func select(districtId: Shared.District.ID) async throws -> Route.ID? {
         guard let district = FetchOne(District.find(districtId)).wrappedValue else {
-            throw APIError.notFound(message: "指定された町が存在しません。")
+            throw AppError.be(.notFound("指定された町が存在しません。"))
         }
         let currentRouteId = try await dataFetcher.launchDistrict(districtId: districtId, clearsExistingData: false)
         userDefaults.defaultDistrictId = district.id

--- a/iOSApp/Sources/Application/SceneUsecase.swift
+++ b/iOSApp/Sources/Application/SceneUsecase.swift
@@ -85,9 +85,7 @@ actor SceneUsecase: SceneUsecaseProtocol {
     }
     
     func signIn(username: String, password: String) async throws -> SignInState {
-        print("Usecase start")
         let signInResult = try await authService.signIn(username, password: password)
-        print("Usecase signIn")
         if case .signedIn(.headquarter(let festivalId)) = signInResult {
             try await dataFetcher.launchFestival(festivalId: festivalId)
             userDefaults.defaultDistrictId = nil

--- a/iOSApp/Sources/Data/Client/AuthProvider.swift
+++ b/iOSApp/Sources/Data/Client/AuthProvider.swift
@@ -57,7 +57,7 @@ extension AuthProvider: DependencyKey {
                     } else if case .confirmSignInWithNewPassword = result.nextStep {
                         return .newPasswordRequired
                     } else {
-                        throw AuthError.unknown("予期しないエラーです \(result.nextStep)")
+                        throw AppError.auth(.unknown("予期しないエラーです \(result.nextStep)"))
                     }
                 } catch {
                     try Self.rethrowAsAuthErrorIfNeeded(error, operation: "signIn")
@@ -98,10 +98,10 @@ extension AuthProvider: DependencyKey {
             getTokens: {
                 do {
                     guard let session = try await Amplify.Auth.fetchAuthSession() as? AWSAuthCognitoSession else {
-                        throw AuthError.unknown("予期せぬエラーが発生しました")
+                        throw AppError.auth(.unknown("予期せぬエラーが発生しました"))
                     }
                     if !session.isSignedIn  {
-                        throw AuthError.auth("ログインしていません。")
+                        throw AppError.auth(.unauthorized("ログインしていません。"))
                     }
                         
                     let result = session.getCognitoTokens()
@@ -190,9 +190,9 @@ extension AuthProvider: DependencyKey {
 
 private extension AuthProvider {
     static func rethrowAsAuthErrorIfNeeded(_ error: Error, operation: String) throws -> Never {
-        if let parsed = AuthError.parse(error, operation: operation) {
+        if let parsed = AppError.parseAuth(error, operation: operation) {
             throw parsed
         }
-        throw error
+        throw error.asAppError
     }
 }

--- a/iOSApp/Sources/Data/Client/AuthProvider.swift
+++ b/iOSApp/Sources/Data/Client/AuthProvider.swift
@@ -97,15 +97,19 @@ extension AuthProvider: DependencyKey {
             
             getTokens: {
                 do {
-                    let session = try await Amplify.Auth.fetchAuthSession() as? AWSAuthCognitoSession
-                    let result = session?.getCognitoTokens()
+                    guard let session = try await Amplify.Auth.fetchAuthSession() as? AWSAuthCognitoSession else {
+                        throw AuthError.unknown("予期せぬエラーが発生しました")
+                    }
+                    if !session.isSignedIn  {
+                        throw AuthError.auth("ログインしていません。")
+                    }
+                        
+                    let result = session.getCognitoTokens()
                     switch result {
                     case .success(let tokens):
                         return tokens.accessToken
                     case .failure(let error):
                         throw error
-                    case .none:
-                        throw AuthError.unknown("アクセストークンの取得に失敗しました。")
                     }
                 } catch {
                     try Self.rethrowAsAuthErrorIfNeeded(error, operation: "getTokens")

--- a/iOSApp/Sources/Data/Client/HTTPClient.swift
+++ b/iOSApp/Sources/Data/Client/HTTPClient.swift
@@ -122,8 +122,10 @@ actor HTTPClient: HTTPClientProtocol {
         let key = cacheKey(url: url, method: method, bodyData: bodyData ?? nil)
 
         // Cache hit
-        if isCache, let cached = cache.object(forKey: key) {
-            return try await decodeResponse(from: cached as Data)
+        if isCache,
+            let cached = cache.object(forKey: key),
+           let decodecCache: Response = try? await decodeResponse(from: cached as Data){
+            return decodecCache
         }
 
         // Build request and execute

--- a/iOSApp/Sources/Data/Client/HTTPClient.swift
+++ b/iOSApp/Sources/Data/Client/HTTPClient.swift
@@ -132,13 +132,13 @@ actor HTTPClient: HTTPClientProtocol {
         do {
             (data, http) = try await execute(request: urlRequest)
         } catch {
-            throw APIError(statusCode: nil, message: "実行中にエラーが発生しました。インターネット接続を確認してください。")
+            throw AppError(statusCode: nil, message: "実行中にエラーが発生しました。インターネット接続を確認してください。")
         }
 
         // If we have HTTP response, check status code
         if let http = http, !(200...299).contains(http.statusCode),
            let response: ErrorResponse = try await decodeResponse(from: data){
-            throw APIError(statusCode: http.statusCode, message: response.localizedDescription)
+            throw AppError(statusCode: http.statusCode, message: response.localizedDescription)
         }
 
         // Success path: cache and decode
@@ -193,7 +193,7 @@ actor HTTPClient: HTTPClientProtocol {
 
     private func makeURL(path: String, query: [String: Any]) throws -> URL {
         guard var components = URLComponents(string: base + path) else {
-            throw NSError(domain: "Invalid URL", code: -1)
+            throw AppError.system(.invalidURL("URLComponents の生成に失敗しました。"))
         }
         if !query.isEmpty {
             components.queryItems = query.compactMap { key, value in
@@ -207,7 +207,7 @@ actor HTTPClient: HTTPClientProtocol {
             }
         }
         guard let url = components.url else {
-            throw NSError(domain: "Invalid URL", code: -1)
+            throw AppError.system(.invalidURL("URL の生成に失敗しました。"))
         }
         return url
     }
@@ -227,31 +227,28 @@ actor HTTPClient: HTTPClientProtocol {
 
     private func encodeBody<Body: Encodable>(_ body: Body?) async throws -> Data? {
         guard let body else { return nil }
-        return try await Task.detached(priority: nil) { [jsonEncoder] in
-            try jsonEncoder.encode(body)
-        }.value
+        do {
+            return try await Task.detached(priority: nil) { [jsonEncoder] in
+                try jsonEncoder.encode(body)
+            }.value
+        } catch {
+            throw AppError.system(.encoding(error.localizedDescription))
+        }
     }
 
     private func decodeResponse<Response: Decodable>(from data: Data) async throws -> Response {
-        try await Task.detached(priority: nil) { [jsonDecoder] in
-            try jsonDecoder.decode(Response.self, from: data)
-        }.value
+        do {
+            return try await Task.detached(priority: nil) { [jsonDecoder] in
+                try jsonDecoder.decode(Response.self, from: data)
+            }.value
+        } catch {
+            throw AppError.system(.decoding(error.localizedDescription))
+        }
     }
 
     private func execute(request: URLRequest) async throws -> (Data, HTTPURLResponse?) {
         let (data, response) = try await session.data(for: request)
         return (data, response as? HTTPURLResponse)
-    }
-
-    private func decodeAPIError(from data: Data, httpStatus: Int) -> Error {
-        if !data.isEmpty, let decoded = try? jsonDecoder.decode(ErrorResponse.self, from: data) {
-            let description = decoded.localizedDescription ?? decoded.message
-            return NSError(domain: "HTTP Error", code: httpStatus, userInfo: [NSLocalizedDescriptionKey: description])
-        }
-        if let text = String(data: data, encoding: .utf8), !text.isEmpty {
-            return NSError(domain: "HTTP Error", code: httpStatus, userInfo: [NSLocalizedDescriptionKey: text])
-        }
-        return NSError(domain: "HTTP Error", code: httpStatus, userInfo: [NSLocalizedDescriptionKey: "HTTP Error \(httpStatus)"])
     }
 
     private func cacheKey(url: URL, method: String, bodyData: Data?) -> NSString {

--- a/iOSApp/Sources/Data/Client/LocationProvider.swift
+++ b/iOSApp/Sources/Data/Client/LocationProvider.swift
@@ -89,10 +89,10 @@ actor LocationProvider: NSObject, LocationProviderProtocol {
 
     func getLocation() -> AsyncValue<CLLocation> {
         if manager?.authorizationStatus == .denied {
-            return .failure(LocationError.authorizationDenied)
+            return .failure(AppError.location(.permissionDenied("位置情報の利用が許可されていません。")))
         }
         if !CLLocationManager.locationServicesEnabled() {
-            return .failure(LocationError.servicesDisabled)
+            return .failure(AppError.location(.servicesDisabled("位置情報サービスが無効です。")))
         }
         
         return value
@@ -126,10 +126,4 @@ extension LocationProviderProtocol {
     func startTracking(backgroundUpdatesAllowed: Bool, onUpdate: ((AsyncValue<CLLocation>) async -> Void)? = nil) async -> Void {
         await startTracking(backgroundUpdatesAllowed: backgroundUpdatesAllowed, onUpdate: onUpdate)
     }
-}
-
-
-enum LocationError: Error {
-    case authorizationDenied
-    case servicesDisabled
 }

--- a/iOSApp/Sources/Domain/Entities/Auth/Error+Auth.swift
+++ b/iOSApp/Sources/Domain/Entities/Auth/Error+Auth.swift
@@ -1,7 +1,7 @@
 import Shared
 
 extension Error {
-    func toAuthError() -> AuthError {
-        .unknown(localizedDescription)
+    func toAppError() -> AppError {
+        asAppError
     }
 }

--- a/iOSApp/Sources/Domain/Entities/Location/Status.swift
+++ b/iOSApp/Sources/Domain/Entities/Location/Status.swift
@@ -13,7 +13,7 @@ enum Status:Sendable, Equatable, Hashable {
     case delete(Date)
     case loading(Date)
     case locationError(Date)
-    case apiError(Date, APIError)
+    case apiError(Date, AppError)
 }
 
 extension Status: Identifiable {

--- a/iOSApp/Sources/Domain/Error/APIError.swift
+++ b/iOSApp/Sources/Domain/Error/APIError.swift
@@ -1,68 +1,255 @@
 //
-//  APIError.swift
+//  AppError.swift
 //  MaTool
 //
 //  Created by 松下和也 on 2025/06/19.
 //
 
 import Foundation
+import Shared
 
-enum APIError: LocalizedError, Equatable, Hashable {
-    case network(message: String)
-    case server(statusCode: Int, message: String)
-    case notFound(message: String)
-    case unauthorized(message: String)
-    case forbidden(message: String)
-    case badRequest(message: String)
-    case decoding(message: String)
-    case encoding(message: String)
-    case unknown(message: String)
-    case cache(message: String)
+enum AppError: LocalizedError, Equatable, Hashable, Sendable {
+    case be(BEErrorKind)
+    case auth(AuthErrorKind)
+    case location(LocationErrorKind)
+    case export(ExportErrorKind)
+    case validation(ValidationErrorKind)
+    case persistence(PersistenceErrorKind)
+    case system(SystemErrorKind)
 
     init(statusCode: Int?, message: String) {
         guard let statusCode else {
-            self = .network(message: message)
+            self = .be(.network(message))
             return
         }
         switch statusCode {
         case 400:
-            self = .badRequest(message: message)
+            self = .be(.badRequest(message))
         case 401:
-            self = .unauthorized(message: message)
+            self = .be(.unauthorized(message))
         case 403:
-            self = .forbidden(message: message)
+            self = .be(.forbidden(message))
         case 404:
-            self = .notFound(message: message)
+            self = .be(.notFound(message))
+        case 409:
+            self = .be(.conflict(message))
         case 500...599:
-            self = .server(statusCode: statusCode, message: message)
+            self = .be(.server(statusCode: statusCode, message: message))
         default:
-            self = .unknown(message: message)
+            self = .be(.unknown(message))
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .be(let error):
+            return error.message
+        case .auth(let error):
+            return error.message
+        case .location(let error):
+            return error.message
+        case .export(let error):
+            return error.message
+        case .validation(let error):
+            return error.message
+        case .persistence(let error):
+            return error.message
+        case .system(let error):
+            return error.message
         }
     }
 
     var errorDescription: String? {
-        switch self {
-        case .network(let message):
-            return message
-        case .notFound(let message):
-            return message
-        case .unauthorized(let message):
-            return "\(message) \nログインし直してください。"
-        case .forbidden(let message):
-            return message
-        case .badRequest(let message):
-            return message
-        case .decoding(let message):
-            return "データの読み取りに失敗しました。 \n\(message)"
-        case .encoding(let message):
-            return "データの変換に失敗しました。 \n\(message)"
-        case .unknown(let message):
-            return "予期せぬエラーが発生しました。 \n\(message)"
-        case .cache(message: let message):
-            return "キャッシュでエラーが発生しました \n\(message)"
-        case .server(statusCode: let statusCode, message: let message):
-            return "サーバーエラーが発生しました。\nステータスコード: \(statusCode)\n\(message) "
+        message
+    }
+}
+
+extension AppError {
+    enum BEErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case unauthorized(String)
+        case forbidden(String)
+        case notFound(String)
+        case conflict(String)
+        case server(statusCode: Int, message: String)
+        case network(String)
+        case timeout(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .forbidden(let message),
+                 .notFound(let message),
+                 .conflict(let message),
+                 .network(let message),
+                 .timeout(let message),
+                 .unknown(let message):
+                return message
+            case .unauthorized(let message):
+                return "\(message)\nログインし直してください。"
+            case .server(let statusCode, let message):
+                return "サーバーエラーが発生しました。\nステータスコード: \(statusCode)\n\(message)"
+            }
+        }
+    }
+
+    enum AuthErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case unauthorized(String)
+        case forbidden(String)
+        case conflict(String)
+        case network(String)
+        case timeout(String)
+        case configuration(String)
+        case cancelled(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .unauthorized(let message),
+                 .forbidden(let message),
+                 .conflict(let message),
+                 .network(let message),
+                 .configuration(let message),
+                 .cancelled(let message),
+                 .unknown(let message):
+                return message
+            case .timeout(let message):
+                return "タイムアウト \(message) このエラーが繰り返し発生する場合は、設定画面からログアウトし、再度サインインしてください。"
+            }
+        }
+    }
+
+    enum LocationErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case unauthorized(String)
+        case forbidden(String)
+        case notFound(String)
+        case network(String)
+        case timeout(String)
+        case servicesDisabled(String)
+        case permissionDenied(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .unauthorized(let message),
+                 .forbidden(let message),
+                 .notFound(let message),
+                 .network(let message),
+                 .timeout(let message),
+                 .servicesDisabled(let message),
+                 .permissionDenied(let message),
+                 .unknown(let message):
+                return message
+            }
+        }
+    }
+
+    enum ExportErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case notFound(String)
+        case conflict(String)
+        case timeout(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .notFound(let message),
+                 .conflict(let message),
+                 .timeout(let message),
+                 .unknown(let message):
+                return message
+            }
+        }
+    }
+
+    enum ValidationErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case conflict(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .conflict(let message),
+                 .unknown(let message):
+                return message
+            }
+        }
+    }
+
+    enum PersistenceErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case notFound(String)
+        case conflict(String)
+        case database(String)
+        case cache(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message),
+                 .notFound(let message),
+                 .conflict(let message),
+                 .database(let message),
+                 .cache(let message),
+                 .unknown(let message):
+                return message
+            }
+        }
+    }
+
+    enum SystemErrorKind: Equatable, Hashable, Sendable {
+        case badRequest(String)
+        case network(String)
+        case timeout(String)
+        case decoding(String)
+        case encoding(String)
+        case invalidURL(String)
+        case unexpected(String)
+        case unknown(String)
+
+        var message: String {
+            switch self {
+            case .badRequest(let message):
+                return message
+            case .network(let message):
+                return message
+            case .timeout(let message):
+                return message
+            case .decoding(let message):
+                return "データの読み取りに失敗しました。\n\(message)"
+            case .encoding(let message):
+                return "データの変換に失敗しました。\n\(message)"
+            case .invalidURL(let message):
+                return "URLの生成に失敗しました。\n\(message)"
+            case .unexpected(let message),
+                 .unknown(let message):
+                return "予期せぬエラーが発生しました。\n\(message)"
+            }
         }
     }
 }
 
+extension Error {
+    var asAppError: AppError {
+        if let error = self as? AppError {
+            return error
+        }
+        if let error = self as? PresentationError {
+            return error.appError
+        }
+        if let error = self as? Point.Error {
+            return .validation(.badRequest(error.localizedDescription))
+        }
+        if let error = self as? DomainError {
+            return .validation(.badRequest(String(describing: error)))
+        }
+        return .system(.unexpected(localizedDescription))
+    }
+}

--- a/iOSApp/Sources/Domain/Error/AuthError.swift
+++ b/iOSApp/Sources/Domain/Error/AuthError.swift
@@ -8,38 +8,10 @@
 import Foundation
 import Amplify
 
-enum AuthError: LocalizedError, Equatable {
-    case network(String)
-    case encoding(String)
-    case decoding(String)
-    case unknown(String)
-    case auth(String)
-    case timeout(String)
-    
-    var errorDescription: String? {
-        switch self {
-        case .network(let message):
-            return "\(message)"
-        case .encoding(let message):
-            return "\(message)"
-        case .decoding(let message):
-            return "\(message)"
-        case .unknown(let message):
-            return "\(message)"
-        case .auth(let message):
-            return "\(message)"
-        case .timeout(let message):
-            return "タイムアウト \(message) このエラーが繰り返し発生する場合は、設定画面からログアウトし、再度サインインしてください。"
-        }
-    }
-}
-
-extension AuthError {
-    static func parse(_ error: Error, operation: String) -> AuthError? {
-        // FIXME: エラー網羅後に削除
-        print(error)
-        if let authError = error as? AuthError {
-            return authError
+extension AppError {
+    static func parseAuth(_ error: Error, operation: String) -> AppError? {
+        if let appError = error as? AppError {
+            return appError
         }
 
         if let amplifyError = error as? any AmplifyError {
@@ -51,32 +23,32 @@ extension AuthError {
             )
 
             if isAuthRelated(description: description) {
-                return .auth(message)
+                return .auth(.unauthorized(message))
             }
             if isNetworkRelated(description: description) {
-                return .network(message)
+                return .auth(.network(message))
             }
-            return .unknown(message)
+            return .auth(.unknown(message))
         }
 
         if error is CancellationError {
-            return .timeout(operation)
+            return .auth(.timeout(operation))
         }
 
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain {
             switch nsError.code {
             case NSURLErrorTimedOut:
-                return .timeout(operation)
+                return .auth(.timeout(operation))
             case NSURLErrorNotConnectedToInternet,
                 NSURLErrorNetworkConnectionLost,
                 NSURLErrorCannotFindHost,
                 NSURLErrorCannotConnectToHost,
                 NSURLErrorDNSLookupFailed:
-                return .network(composeMessage(
+                return .auth(.network(composeMessage(
                     main: "通信環境が不安定なため処理に失敗しました。",
                     recovery: "通信状況をご確認のうえ、時間をおいて再試行してください。"
-                ))
+                )))
             default:
                 break
             }
@@ -98,7 +70,6 @@ extension AuthError {
 
     private static func localizedAmplifyDescription(_ description: String) -> String {
         switch normalize(description) {
-        // MARK: - 出現を確認済
         case "Incorrect username or password":
             return "ユーザー名またはパスワードが正しくありません。"
         case "Username is required to signIn":
@@ -111,7 +82,6 @@ extension AuthError {
             return "認証コードが正しくありません。もう一度お試しください。"
         case "Attempt limit exceeded, please try after some time":
             return "試行回数が限界に達しています。しばらくしてから再度お試しください。"
-        // MARK: - 未確認
         case "Username is required to signUp":
             return "サインアップに必要なユーザー名が入力されていません。"
         case "Password is required to signUp":
@@ -219,132 +189,35 @@ extension AuthError {
             "A network error occurred while trying to fetch user sub",
             "A network error occurred while trying to fetch AWS Cognito Tokens":
             return "通信エラーのため、認証情報を取得できませんでした。"
-        case "There is no user signed in to the Auth category":
-            return "サインイン中のユーザーがいないため、認証操作を実行できませんでした。"
         default:
-            return "認証処理でエラーが発生しました。"
+            return description
         }
     }
 
     private static func localizedAmplifyRecovery(_ recovery: String) -> String {
-        switch normalize(recovery) {
-        // MARK: - 確認
-        case "Check whether the given values are correct and the user is authorized to perform the operation":
-            return "入力値（ユーザー名・パスワード）と、操作権限が正しいか確認してください。"
-        case "Make sure that a valid username is passed during signIn":
-            return "サインイン時に有効なユーザー名を入力してください。"
-        case "Make sure that a valid password is passed during signIn":
-            return "サインイン時に有効なパスワードを入力してください。"
-        case "Retry with a valid code":
-            return "有効な確認コードを入力し、もう一度試してみてください。"
-        // MARK: - 未確認
-        case "Make sure that a valid username is passed for signUp":
-            return "サインアップ時に有効なユーザー名を入力してください。"
-        case "Make sure that a valid password is passed for signUp":
-            return "サインアップ時に有効なパスワードを入力してください。"
-        case "Make sure that a valid username is passed for confirmSignUp":
-            return "サインアップ確認時に有効なユーザー名を入力してください。"
-        case "Make sure that a valid code is passed for confirmSignUp":
-            return "サインアップ確認時に有効な確認コードを入力してください。"
-        case "Make sure that a valid challenge response is passed for confirmSignIn":
-            return "サインイン確認時に有効な応答値を指定してください。"
-        case "Make sure that a valid username is passed for confirmResetPassword":
-            return "パスワード再設定確認時に有効なユーザー名を入力してください。"
-        case "Make sure that a valid newPassword is passed for confirmResetPassword":
-            return "パスワード再設定確認時に有効な新しいパスワードを入力してください。"
-        case "Make sure that a valid confirmationCode is passed for confirmResetPassword":
-            return "パスワード再設定確認時に有効な確認コードを入力してください。"
-        case "Make sure that a valid username is passed for resetPassword":
-            return "パスワードリセット時に有効なユーザー名を入力してください。"
-        case "Make sure the plugin configuration is JSONValue":
-            return "認証プラグイン設定をJSON形式で正しく設定してください。"
-        case "Make sure the value for the plugin is a dictionary literal":
-            return "認証プラグイン設定を辞書形式で正しく設定してください。"
-        case "Make sure that the signIn URL has not been modified during the signIn flow":
-            return "サインイン中にURLが書き換わっていないか確認し、再試行してください。"
-        case "Present the signIn UI again for the user to sign in":
-            return "サインイン画面を再表示し、再度サインインしてください。"
-        case "Present the signOut UI again for the user to sign out":
-            return "サインアウト操作を再実行してください。"
-        case "Retry by providing a presentation context to present the webUI":
-            return "表示コンテキストを正しく指定して再試行してください。"
-        case "Make sure that the app can present an ASWebAuthenticationSession":
-            return "アプリがASWebAuthenticationSessionを表示できる状態か確認してください。"
-        case "Check the configuration to make sure that HostedUI related information are present":
-            return "Hosted UIの設定値（URL等）が正しいか確認してください。"
-        case "Reach out with amplify team via github to raise an issue":
-            return "同じ事象が続く場合は実装設定を見直し、必要ならAmplifyのIssue情報を確認してください。"
-        case "Check if the the configuration provided are correct":
-            return "認証設定値が正しいか確認してください。"
-        case "SignIn to Auth category by using one of the sign in methods and then call user attributes apis":
-            return "サインイン後に、再度同じ操作を行ってください。"
-        case "Get the current user Auth.getCurrentUser() and make the request":
-            return "サインイン状態を確認し、必要に応じて再ログインしてから再試行してください。"
-        case "Call Auth.signIn to sign in a user or enable unauthenticated access in AWS Cognito Identity Pool":
-            return "サインインするか、必要に応じてIdentity Poolの未認証アクセス設定を確認してください。"
-        case "Call Auth.signIn to sign in a user and then call Auth.fetchSession":
-            return "再ログイン後に処理を再試行してください。"
-        case "Follow the steps to configure AWS Cognito Identity Pool and try again":
-            return "AWS Cognito Identity Poolを設定したうえで再試行してください。"
-        case "Change password require a user signed in to Auth category, use one of the signIn apis to signIn":
-            return "サインイン後にパスワード変更を再実行してください。"
-        case "Re-authenticate the user by using one of the signIn apis",
-            "Invoke Auth.signIn to re-authenticate the user":
-            return "再ログインしてから再試行してください。"
-        case "Try again with exponential backoff":
-            return "通信状況をご確認のうえ、少し時間をおいて再試行してください。"
-        case "SignIn to Auth category by using one of the sign in methods and then try again":
-            return "サインイン後に再試行してください。"
-        case "Tokens are not valid with user signed in through AWS Cognito Identity Pool":
-            return "User Pool経由でサインインし直して再試行してください。"
-        case "User sub are not valid with user signed in through AWS Cognito Identity Pool":
-            return "User Pool経由でサインインし直して再試行してください。"
-        case "Invoke the associate WebAuthn credential flow again":
-            return "WebAuthn登録を再実行してください。"
-        case "Remove the old WebAuthn credential and try again":
-            return "既存のWebAuthn資格情報を削除してから再試行してください。"
-        case "Invoke the sign in with WebAuthn flow again":
-            return "WebAuthnサインインを再実行してください。"
-        case "Make sure that the parameters passed are valid":
-            return "入力された値が正しいか確認してください。"
-        default:
-            return "インターネット接続状況を確認してください。繋がっている場合はしばらく待ってから再試行してください。"
-        }
-    }
-
-    private static func normalize(_ text: String) -> String {
-        var value = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if value.hasSuffix(".") {
-            value.removeLast()
-        }
-        return value
+        recovery
     }
 
     private static func isAuthRelated(description: String) -> Bool {
-        let lower = description.lowercased()
-        return lower.contains("signed in")
-            || lower.contains("session expired")
-            || lower.contains("validate the user")
-            || lower.contains("incorrect username or password")
-            || lower.contains("authorized to perform the operation")
-            || lower.contains("change password")
-            || lower.contains("fetch attributes")
-            || lower.contains("update attributes")
-            || lower.contains("confirm attribute")
-            || lower.contains("cognito tokens")
-            || lower.contains("required to signin")
-            || lower.contains("required to signup")
-            || lower.contains("required to confirmsignup")
-            || lower.contains("required to confirmsignin")
-            || lower.contains("required to resetpassword")
-            || lower.contains("required to confirmresetpassword")
-            || lower.contains("challengeresponse")
+        let value = normalize(description)
+        return value.contains("password")
+            || value.contains("username")
+            || value.contains("sign")
+            || value.contains("session")
+            || value.contains("credential")
+            || value.contains("token")
+            || value.contains("auth")
     }
 
     private static func isNetworkRelated(description: String) -> Bool {
-        let lower = description.lowercased()
-        return lower.contains("network error")
-            || lower.contains("cannot connect")
-            || lower.contains("timed out")
+        let value = normalize(description)
+        return value.contains("network")
+            || value.contains("connection")
+            || value.contains("timeout")
+            || value.contains("host")
+    }
+
+    private static func normalize(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -12,12 +12,6 @@ import SQLiteData
 
 @MainActor
 struct RouteSnapshotter: Equatable {
-    enum Error: Swift.Error {
-        case notFound
-        case snapshotterNotAvailable
-        case imageCreationFailed
-    }
-    
     var route: Route
     var period: Period
     var points: [Point]
@@ -32,7 +26,7 @@ struct RouteSnapshotter: Equatable {
     init (route: Route, points: [Point]) throws {
         guard let district: District = FetchOne(District.find(route.districtId)).wrappedValue,
               let period: Period = FetchOne(Period.find(route.periodId)).wrappedValue else {
-            throw Error.notFound
+            throw AppError.export(.notFound("必要な情報の取得に失敗しました。"))
         }
         self.district = district
         self.period = period
@@ -79,11 +73,11 @@ struct RouteSnapshotter: Equatable {
             withExtendedLifetime(snapshotter) {
                 snapshotter.start { snapshot, error in
                     if let error = error {
-                        continuation.resume(throwing: error)
+                        continuation.resume(throwing: error.asAppError)
                         return
                     }
                     guard let snapshot = snapshot else {
-                        continuation.resume(throwing: Self.Error.snapshotterNotAvailable)
+                        continuation.resume(throwing: AppError.export(.conflict("Snapshotterサービスが利用できません。")))
                         return
                     }
                     
@@ -109,7 +103,7 @@ struct RouteSnapshotter: Equatable {
                     drawTitleTextBlock(text: titleText, in: options, drawnRects: &drawnRects)
                     
                     guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
-                        continuation.resume(throwing: Self.Error.imageCreationFailed)
+                        continuation.resume(throwing: AppError.export(.conflict("地図の画像を作成できませんでした。")))
                         return
                     }
                     
@@ -356,17 +350,4 @@ struct RouteSnapshotter: Equatable {
     }
     
     static let a4size = CGSize(width: 594, height: 420)
-}
-
-extension RouteSnapshotter.Error {
-    var localizedDescription: String {
-        switch self {
-        case .notFound:
-            "必要な情報の取得に失敗しました。"
-        case .imageCreationFailed:
-            "地図の画像を作成できませんでした。"
-        case .snapshotterNotAvailable:
-            "Snapshotterサービスが利用できません。"
-        }
-    }
 }

--- a/iOSApp/Sources/Presentation/Utils/Status+Text.swift
+++ b/iOSApp/Sources/Presentation/Utils/Status+Text.swift
@@ -10,7 +10,7 @@ extension Status {
         case .locationError(let date):
             return "\(date.text(of: "HH:mm:ss")) 取得失敗"
         case .apiError(let date, let error):
-            return "\(date.text(of: "HH:mm:ss")) 送信失敗 \(error.localizedDescription)"
+            return "\(date.text(of: "HH:mm:ss")) 送信失敗 \(error.message)"
         case .delete(let date):
             return "\(date.text(of: "HH:mm:ss")) 削除済み"
         }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Edit/DistrictEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Edit/DistrictEditFeature.swift
@@ -40,7 +40,7 @@ struct DistrictEditFeature {
         case areaTapped
         case performanceAddTapped
         case performanceEditTapped(Performance)
-        case postReceived(VoidTaskResult)
+        case postReceived(VoidAppResult)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -86,7 +86,7 @@ struct DistrictEditFeature {
                 return .none
             case .postReceived(.failure(let error)):
                 state.isLoading = false
-                    state.alert = AlertFeature.error("保存に失敗しました。\(error.localizedDescription)")
+                    state.alert = AlertFeature.error("保存に失敗しました。\(error.message)")
                 return .none
             case .destination(.presented(let childAction)):
                 switch childAction {

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/Point/PointEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/Point/PointEditFeature.swift
@@ -59,7 +59,7 @@ struct PointEditFeature {
                 do {
                     try state.validate()
                 } catch  {
-                    state.alert = AlertFeature.error(error.localizedDescription)
+                    state.alert = AlertFeature.error(error.asAppError.message)
                 }
                 return .none
             case .alert:

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -92,9 +92,9 @@ struct RouteEditFeature{
         case passageDeleteTapped(Int)
         case sourceSelected(RouteEntry)
         case saveReceived(VoidAppResult)
-        case copyPrepared(Result<Route.ID, AppError>)
+        case copyPrepared(AppResult<Route.ID>)
         case deleteReceived(VoidAppResult)
-        case previewPrepared(Result<ExportedItem, AppError>)
+        case previewPrepared(AppResult<ExportedItem>)
         case point(PresentationAction<PointEditFeature.Action>)
         case alert(PresentationAction<AlertDestination.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -91,10 +91,10 @@ struct RouteEditFeature{
         case passageMoved(from: IndexSet, to: Int)
         case passageDeleteTapped(Int)
         case sourceSelected(RouteEntry)
-        case saveReceived(VoidTaskResult)
-        case copyPrepared(TaskResult<Route.ID>)
-        case deleteReceived(VoidTaskResult)
-        case previewPrepared(TaskResult<ExportedItem>)
+        case saveReceived(VoidAppResult)
+        case copyPrepared(Result<Route.ID, AppError>)
+        case deleteReceived(VoidAppResult)
+        case previewPrepared(Result<ExportedItem, AppError>)
         case point(PresentationAction<PointEditFeature.Action>)
         case alert(PresentationAction<AlertDestination.Action>)
     }
@@ -156,7 +156,7 @@ struct RouteEditFeature{
                     case .update:
                         try await dataFetcher.update(state.route, points: state.points, passages: state.passages)
                     case .preview:
-                        throw APIError.unknown(message: "権限がありません")
+                        throw AppError.be(.forbidden("権限がありません"))
                     }
                     await dismiss()
                 }
@@ -298,7 +298,7 @@ struct RouteEditFeature{
                 .copyPrepared(.failure(let error)),
                 .previewPrepared(.failure(let error)):
                 state.isLoading = false
-                state.alert = .notice(.error(error.localizedDescription))
+                state.alert = .notice(.error(error))
                 return .none
             default:
                 return .none

--- a/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
@@ -51,11 +51,11 @@ struct DistrictDashboardFeature {
         case onLocation
         case submissionExportTapped
         case tableExportTapped
-        case exportReceived(Result<URL, AppError>)
+        case exportReceived(AppResult<URL>)
         case destination(PresentationAction<Destination.Action>)
         case signOutTapped
-        case signOutReceived(Result<UserRole, AppError>)
-        case routeEditReceived(Result<RouteSlot, AppError>)
+        case signOutReceived(AppResult<UserRole>)
+        case routeEditReceived(AppResult<RouteSlot>)
         case dismissTapped
         case alert(PresentationAction<AlertFeature.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
@@ -51,11 +51,11 @@ struct DistrictDashboardFeature {
         case onLocation
         case submissionExportTapped
         case tableExportTapped
-        case exportReceived(TaskResult<URL>)
+        case exportReceived(Result<URL, AppError>)
         case destination(PresentationAction<Destination.Action>)
         case signOutTapped
-        case signOutReceived(TaskResult<UserRole>)
-        case routeEditReceived(TaskResult<RouteSlot>)
+        case signOutReceived(Result<UserRole, AppError>)
+        case routeEditReceived(Result<RouteSlot, AppError>)
         case dismissTapped
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -106,7 +106,7 @@ struct DistrictDashboardFeature {
                 return .none
             case .routeEditReceived(.failure(let error)):
                 state.isRouteLoading = false
-                state.alert = .error(error.localizedDescription)
+                state.alert = .error(error.message)
                 return .none
             case .locationPrepared(isTracking: let isTracking, Interval: let interval):
                 state.destination = .location(
@@ -135,7 +135,7 @@ struct DistrictDashboardFeature {
                 return .none
             case .exportReceived(.failure(let error)):
                 state.isExportLoading = false
-                state.alert = .error(error.localizedDescription)
+                state.alert = .error(error.message)
                 return .none
             case .destination(.presented(let childAction)):
                 switch childAction {
@@ -156,7 +156,7 @@ struct DistrictDashboardFeature {
                 }
             case .signOutReceived(.failure(let error)):
                 state.isAWSLoading = false
-                state.alert = .error("ログアウトに失敗しました。 \(error.localizedDescription)")
+                state.alert = .error("ログアウトに失敗しました。 \(error.message)")
                 return .none
             case .dismissTapped:
                 return .dismiss

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/DistrictCreateFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/DistrictCreateFeature.swift
@@ -24,7 +24,7 @@ struct DistrictCreateFeature {
         case binding(BindingAction<State>)
         case createTapped
         case cancelTapped
-        case createReceived(VoidTaskResult)
+        case createReceived(VoidAppResult)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -50,7 +50,7 @@ struct DistrictCreateFeature {
                 return .none
             case .createReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/DistrictReissueFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/DistrictReissueFeature.swift
@@ -23,7 +23,7 @@ struct DistrictReissueFeature {
         case binding(BindingAction<State>)
         case reissueTapped
         case cancelTapped
-        case reissueReceived(VoidTaskResult)
+        case reissueReceived(VoidAppResult)
         case alert(PresentationAction<AlertFeature.Action>)
     }
 
@@ -53,7 +53,7 @@ struct DistrictReissueFeature {
                 return .none
             case .reissueReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -40,9 +40,9 @@ struct HeadquarterDistrictDetailFeature {
         case routeSelected(RouteSlot)
         case batchExportTapped
         case tableExportTapped
-        case updateReceived(VoidTaskResult)
-        case routeReceived(TaskResult<RouteEntry>)
-        case batchExportReceived(TaskResult<URL>)
+        case updateReceived(VoidAppResult)
+        case routeReceived(Result<RouteEntry, AppError>)
+        case batchExportReceived(Result<URL, AppError>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -100,7 +100,7 @@ struct HeadquarterDistrictDetailFeature {
                 .routeReceived(.failure(let error)),
                 .batchExportReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .destination(_):
                 return .none

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -41,8 +41,8 @@ struct HeadquarterDistrictDetailFeature {
         case batchExportTapped
         case tableExportTapped
         case updateReceived(VoidAppResult)
-        case routeReceived(Result<RouteEntry, AppError>)
-        case batchExportReceived(Result<URL, AppError>)
+        case routeReceived(AppResult<RouteEntry>)
+        case batchExportReceived(AppResult<URL>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
@@ -39,11 +39,11 @@ struct HeadquarterDistrictListFeature {
         case createTapped
         case reorderTapped
         case districtMoved(from: IndexSet, to: Int)
-        case reorderReceived(VoidTaskResult)
+        case reorderReceived(VoidAppResult)
         case batchExportTapped
         case tableExportTapped
-        case selectedReceived(TaskResult<District>)
-        case batchExportReceived(TaskResult<[URL]>)
+        case selectedReceived(Result<District, AppError>)
+        case batchExportReceived(Result<[URL], AppError>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -122,7 +122,7 @@ struct HeadquarterDistrictListFeature {
                 .reorderReceived(.failure(let error)),
                 .batchExportReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .destination:
                 return .none

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
@@ -42,8 +42,8 @@ struct HeadquarterDistrictListFeature {
         case reorderReceived(VoidAppResult)
         case batchExportTapped
         case tableExportTapped
-        case selectedReceived(Result<District, AppError>)
-        case batchExportReceived(Result<[URL], AppError>)
+        case selectedReceived(AppResult<District>)
+        case batchExportReceived(AppResult<[URL]>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Edit/FestivalEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Edit/FestivalEditFeature.swift
@@ -37,7 +37,7 @@ struct FestivalEditFeature {
         case saveTapped
         case cancelTapped
         case baseTapped
-        case putReceived(VoidTaskResult)
+        case putReceived(VoidAppResult)
         case onCheckpointEdit(Checkpoint)
         case onCheckpointAdd
         case hazardTapped(HazardSection)
@@ -89,7 +89,7 @@ struct FestivalEditFeature {
                 return .none
             case .putReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("保存に失敗しました。\(error.localizedDescription)")
+                state.alert = AlertFeature.error("保存に失敗しました。\(error.message)")
                 return .none
             case .onCheckpointEdit(let item):
                 state.destination = .checkpoint(

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Period/PeriodEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Period/PeriodEditFeature.swift
@@ -27,9 +27,9 @@ struct PeriodEditFeature {
         case cancelTapped
         case deleteTapped
         case dateChanged(SimpleDate)
-        case saveReceived(VoidTaskResult)
-        case deleteReceived(VoidTaskResult)
-        case catched(APIError)
+        case saveReceived(VoidAppResult)
+        case deleteReceived(VoidAppResult)
+        case catched(AppError)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -61,7 +61,7 @@ struct PeriodEditFeature {
             case .saveReceived(.failure(let error)),
                 .deleteReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             default:
                 return .none

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Period/PeriodListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Period/PeriodListFeature.swift
@@ -44,7 +44,7 @@ struct PeriodListFeature {
         case archiveTapped(State.YearlyPeriods)
         case periodCreateTapped
         case batchCreateTapped(Int)
-        case batchCreateReceived(VoidTaskResult)
+        case batchCreateReceived(VoidAppResult)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -84,7 +84,7 @@ struct PeriodListFeature {
                 return .none
             case .batchCreateReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .alert(.presented(_)):
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Top/FestivalDashboardFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Top/FestivalDashboardFeature.swift
@@ -47,7 +47,7 @@ struct FestivalDashboardFeature {
         case changePasswordTapped
         case updateEmailTapped
         case signOutTapped
-        case signOutReceived(TaskResult<UserRole>)
+        case signOutReceived(Result<UserRole, AppError>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -84,7 +84,7 @@ struct FestivalDashboardFeature {
                 }
             case .signOutReceived(.failure(let error)):
                 state.isAuthLoading = false
-                state.alert = AlertFeature.error("ログアウトに失敗しました　\(error.localizedDescription)")
+                state.alert = AlertFeature.error("ログアウトに失敗しました　\(error.message)")
                 return .none
             case .destination(.presented(.edit(.putReceived(.success)))):
                 state.destination = nil

--- a/iOSApp/Sources/Presentation/View/Admin/Region/Top/FestivalDashboardFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/Top/FestivalDashboardFeature.swift
@@ -47,7 +47,7 @@ struct FestivalDashboardFeature {
         case changePasswordTapped
         case updateEmailTapped
         case signOutTapped
-        case signOutReceived(Result<UserRole, AppError>)
+        case signOutReceived(AppResult<UserRole>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/App/Home/HomeFeature.swift
+++ b/iOSApp/Sources/Presentation/View/App/Home/HomeFeature.swift
@@ -49,7 +49,7 @@ struct HomeFeature {
         case infoTapped
         case adminTapped
         case settingsTapped
-        case settingsPrepared(VoidTaskResult)
+        case settingsPrepared(VoidAppResult)
         case loginSucceeded(UserRole)
         case loginSucceededAfterDismiss(UserRole)
         case destination(PresentationAction<Destination.Action>)

--- a/iOSApp/Sources/Presentation/View/App/Onboarding/Onboarding.swift
+++ b/iOSApp/Sources/Presentation/View/App/Onboarding/Onboarding.swift
@@ -41,7 +41,7 @@ struct OnboardingFeature {
         case adminTapped
         case districtSelected(District)
         case festivalDidSet(VoidAppResult)
-        case districtDidSet(Result<Route.ID?, AppError>)
+        case districtDidSet(AppResult<Route.ID?>)
     }
     
     @Dependency(SceneUsecaseKey.self) var sceneUsecase

--- a/iOSApp/Sources/Presentation/View/App/Onboarding/Onboarding.swift
+++ b/iOSApp/Sources/Presentation/View/App/Onboarding/Onboarding.swift
@@ -40,8 +40,8 @@ struct OnboardingFeature {
         case externalGuestTapped
         case adminTapped
         case districtSelected(District)
-        case festivalDidSet(VoidTaskResult)
-        case districtDidSet(TaskResult<Route.ID?>)
+        case festivalDidSet(VoidAppResult)
+        case districtDidSet(Result<Route.ID?, AppError>)
     }
     
     @Dependency(SceneUsecaseKey.self) var sceneUsecase

--- a/iOSApp/Sources/Presentation/View/App/Settings/SettingsFeature.swift
+++ b/iOSApp/Sources/Presentation/View/App/Settings/SettingsFeature.swift
@@ -51,9 +51,9 @@ struct SettingsFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case signOutTapped
-        case signOutReceived(TaskResult<UserRole>)
-        case festivalSelectReceived(TaskResult<FestivalSelectionResult>)
-        case districtSelectReceived(TaskResult<Route.ID?>)
+        case signOutReceived(Result<UserRole, AppError>)
+        case festivalSelectReceived(Result<FestivalSelectionResult, AppError>)
+        case districtSelectReceived(Result<Route.ID?, AppError>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -90,7 +90,7 @@ struct SettingsFeature {
                 state.alert = AlertFeature.success("ログアウトしました")
                 return .none
             case .signOutReceived(.failure(let error)):
-                state.alert = AlertFeature.error("情報の取得に失敗しました \(error.localizedDescription)")
+                state.alert = AlertFeature.error("情報の取得に失敗しました \(error.message)")
                 return .none
             case .festivalSelectReceived(.success(let result)):
                 if case .changed = result {
@@ -105,7 +105,7 @@ struct SettingsFeature {
             case .festivalSelectReceived(.failure(let error)),
                 .districtSelectReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("情報の取得に失敗しました \(error.localizedDescription)")
+                state.alert = AlertFeature.error("情報の取得に失敗しました \(error.message)")
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/App/Settings/SettingsFeature.swift
+++ b/iOSApp/Sources/Presentation/View/App/Settings/SettingsFeature.swift
@@ -51,9 +51,9 @@ struct SettingsFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case signOutTapped
-        case signOutReceived(Result<UserRole, AppError>)
-        case festivalSelectReceived(Result<FestivalSelectionResult, AppError>)
-        case districtSelectReceived(Result<Route.ID?, AppError>)
+        case signOutReceived(AppResult<UserRole>)
+        case festivalSelectReceived(AppResult<FestivalSelectionResult>)
+        case districtSelectReceived(AppResult<Route.ID?>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     

--- a/iOSApp/Sources/Presentation/View/Auth/ChangePassword/ChangePasswordFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/ChangePassword/ChangePasswordFeature.swift
@@ -25,7 +25,7 @@ struct ChangePasswordFeature {
         case binding(BindingAction<State>)
         case okTapped
         case dismissTapped
-        case received(VoidTaskResult)
+        case received(VoidAppResult)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -57,7 +57,7 @@ struct ChangePasswordFeature {
                 return .none
             case .received(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("変更に失敗しました。\(error.localizedDescription)")
+                state.alert = AlertFeature.error("変更に失敗しました。\(error.message)")
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Auth/ConfirmSignIn/ConfirmSignInFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/ConfirmSignIn/ConfirmSignInFeature.swift
@@ -24,7 +24,7 @@ struct ConfirmSignInFeature {
         case binding(BindingAction<State>)
         case submitTapped
         case dismissTapped
-        case received(TaskResult<UserRole>)
+        case received(Result<UserRole, AppError>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -54,7 +54,7 @@ struct ConfirmSignInFeature {
                 return .none
             case .received(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("送信に失敗しました。\(error.localizedDescription)")
+                state.alert = AlertFeature.error("送信に失敗しました。\(error.message)")
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Auth/ConfirmSignIn/ConfirmSignInFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/ConfirmSignIn/ConfirmSignInFeature.swift
@@ -24,7 +24,7 @@ struct ConfirmSignInFeature {
         case binding(BindingAction<State>)
         case submitTapped
         case dismissTapped
-        case received(Result<UserRole, AppError>)
+        case received(AppResult<UserRole>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     

--- a/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
@@ -31,7 +31,7 @@ struct LoginFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case signInTapped
-        case received(Result<SignInState, AppError>)
+        case received(AppResult<SignInState>)
         case resetPasswordTapped
         case destination(PresentationAction<Destination.Action>)
         case confirmSignInCompleted(UserRole)

--- a/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
@@ -31,7 +31,7 @@ struct LoginFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case signInTapped
-        case received(TaskResult<SignInState>)
+        case received(Result<SignInState, AppError>)
         case resetPasswordTapped
         case destination(PresentationAction<Destination.Action>)
         case confirmSignInCompleted(UserRole)
@@ -52,10 +52,6 @@ struct LoginFeature {
                 return .task(Action.received) { [state] in
                     try await sceneUsecase.signIn(username: state.id, password: state.password)
                 }
-                return .run { [state] send in
-                    let result = try await sceneUsecase.signIn(username: state.id, password: state.password)
-                    send(.received(result))
-                }
             case .dismissTapped:
                 return .dismiss
             case .resetPasswordTapped:
@@ -68,7 +64,7 @@ struct LoginFeature {
                 return .none
             case .received(.failure(let error)):
                 state.isLoading = false
-                state.errorMessage = error.localizedDescription
+                state.errorMessage = error.message
                 return .none
             case .destination(.presented(.resetPassword(.confirmResetReceived(.success)))):
                 state.destination = nil

--- a/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/Login/LoginFeature.swift
@@ -52,6 +52,10 @@ struct LoginFeature {
                 return .task(Action.received) { [state] in
                     try await sceneUsecase.signIn(username: state.id, password: state.password)
                 }
+                return .run { [state] send in
+                    let result = try await sceneUsecase.signIn(username: state.id, password: state.password)
+                    send(.received(result))
+                }
             case .dismissTapped:
                 return .dismiss
             case .resetPasswordTapped:

--- a/iOSApp/Sources/Presentation/View/Auth/ResetPassword/ResetPasswordFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/ResetPassword/ResetPasswordFeature.swift
@@ -33,8 +33,8 @@ struct ResetPasswordFeature {
         case binding(BindingAction<State>)
         case enterUsername(NavigationAction)
         case enterCode(NavigationAction)
-        case resetReceived(VoidTaskResult)
-        case confirmResetReceived(VoidTaskResult)
+        case resetReceived(VoidAppResult)
+        case confirmResetReceived(VoidAppResult)
         case resendTapped
         case alert(PresentationAction<AlertFeature.Action>)
         
@@ -89,14 +89,14 @@ struct ResetPasswordFeature {
                 return .none
             case .resetReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("リセットに失敗しました。\(error.localizedDescription)")
+                state.alert = AlertFeature.error("リセットに失敗しました。\(error.message)")
                 return .none
             case .confirmResetReceived(.success):
                 state.isLoading = false
                 return .none
             case .confirmResetReceived(.failure(let error)):
                 state.isLoading = false
-                state.alert = AlertFeature.error("リセットに失敗しました。\(error.localizedDescription)")
+                state.alert = AlertFeature.error("リセットに失敗しました。\(error.message)")
                 return .none
             case .alert:
                 state.alert = nil

--- a/iOSApp/Sources/Presentation/View/Auth/UpdateEmail/UpdateEmailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/UpdateEmail/UpdateEmailFeature.swift
@@ -39,8 +39,8 @@ struct UpdateEmailFeature {
         }
         
         case resendTapped
-        case updateReceived(TaskResult<UpdateEmailState>)
-        case confirmUpdateReceived(VoidTaskResult)
+        case updateReceived(Result<UpdateEmailState, AppError>)
+        case confirmUpdateReceived(VoidAppResult)
         case errorAlert(PresentationAction<AlertFeature.Action>)
         case completeAlert(PresentationAction<AlertFeature.Action>)
     }
@@ -78,7 +78,7 @@ struct UpdateEmailFeature {
                 return .none
             case .updateReceived(.failure(let error)):
                 state.isLoading = false
-                state.errorAlert = .error(error.localizedDescription)
+                state.errorAlert = .error(error.message)
                 return .none
             case .confirmUpdateReceived(.success):
                 state.isLoading = false
@@ -86,7 +86,7 @@ struct UpdateEmailFeature {
                 return .none
             case .confirmUpdateReceived(.failure(let error)):
                 state.isLoading = false
-                state.errorAlert = .error(error.localizedDescription)
+                state.errorAlert = .error(error.message)
                 return .none
             case .errorAlert:
                 state.errorAlert = nil

--- a/iOSApp/Sources/Presentation/View/Auth/UpdateEmail/UpdateEmailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Auth/UpdateEmail/UpdateEmailFeature.swift
@@ -39,7 +39,7 @@ struct UpdateEmailFeature {
         }
         
         case resendTapped
-        case updateReceived(Result<UpdateEmailState, AppError>)
+        case updateReceived(AppResult<UpdateEmailState>)
         case confirmUpdateReceived(VoidAppResult)
         case errorAlert(PresentationAction<AlertFeature.Action>)
         case completeAlert(PresentationAction<AlertFeature.Action>)

--- a/iOSApp/Sources/Presentation/View/Public/Info/District/DistrictInfoFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Info/District/DistrictInfoFeature.swift
@@ -27,7 +27,7 @@ struct DistrictInfoFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case mapTapped
-        case routeIdReceived(Result<Route.ID?, AppError>)
+        case routeIdReceived(AppResult<Route.ID?>)
     }
     
     @Dependency(\.dismiss) var dismiss

--- a/iOSApp/Sources/Presentation/View/Public/Info/District/DistrictInfoFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Info/District/DistrictInfoFeature.swift
@@ -27,7 +27,7 @@ struct DistrictInfoFeature {
         case binding(BindingAction<State>)
         case dismissTapped
         case mapTapped
-        case routeIdReceived(TaskResult<Route.ID?>)
+        case routeIdReceived(Result<Route.ID?, AppError>)
     }
     
     @Dependency(\.dismiss) var dismiss

--- a/iOSApp/Sources/Presentation/View/Public/Info/List/InfoListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Info/List/InfoListFeature.swift
@@ -44,7 +44,7 @@ struct InfoListFeature {
         case districtTapped(District)
         case mapRequested(MapRequest)
         case dismissTapped
-        case districtReceived(TaskResult<District>)
+        case districtReceived(Result<District, AppError>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -78,7 +78,7 @@ struct InfoListFeature {
                 state.isLoading = false
                 return .none
             case .districtReceived(.failure(let error)):
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 state.isLoading = false
                 return .none
             case .destination(.presented(.festival(.mapTapped))):
@@ -91,7 +91,7 @@ struct InfoListFeature {
                 state.destination = nil
                 return .send(.mapRequested(.route(festival: state.festival, district: district, routeId: routeId)))
             case .destination(.presented(.district(.routeIdReceived(.failure(let error))))):
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             case .destination:
                 return .none

--- a/iOSApp/Sources/Presentation/View/Public/Info/List/InfoListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Info/List/InfoListFeature.swift
@@ -44,7 +44,7 @@ struct InfoListFeature {
         case districtTapped(District)
         case mapRequested(MapRequest)
         case dismissTapped
-        case districtReceived(Result<District, AppError>)
+        case districtReceived(AppResult<District>)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }

--- a/iOSApp/Sources/Presentation/View/Public/Map/Locations/PublicLocationsFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Map/Locations/PublicLocationsFeature.swift
@@ -31,7 +31,7 @@ struct PublicLocationsFeature {
         case userFocusTapped
         case userLocationReceived(Coordinate)
         case reloadTapped
-        case reloadReceived(VoidTaskResult)
+        case reloadReceived(VoidAppResult)
         case alert(PresentationAction<AlertFeature.Action>)
     }
     
@@ -64,7 +64,7 @@ struct PublicLocationsFeature {
                     await send(.userLocationReceived(Coordinate.fromCL(coordinate)))
                 }
             case .reloadReceived(.failure(let error)):
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = AlertFeature.error(error.message)
                 return .none
             default:
                 return .none

--- a/iOSApp/Sources/Presentation/View/Public/Map/Root/PublicMapFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Map/Root/PublicMapFeature.swift
@@ -43,7 +43,7 @@ struct PublicMapFeature {
         case dismissTapped
         case contentSelected(Content)
         case routePrepared(District, Route.ID?)
-        case errorCaught(APIError)
+        case errorCaught(AppError)
         case destination(PresentationAction<Destination.Action>)
         case alert(PresentationAction<AlertFeature.Action>)
     }
@@ -117,7 +117,7 @@ struct PublicMapFeature {
                 )
                 return .none
             case .errorCaught(let error):
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = .error(error)
                 return .none
             case .destination:
                 return destinationAction(state: &state, action: action)
@@ -141,7 +141,7 @@ struct PublicMapFeature {
     
     func routeEffect(_ district: District, periodId: Period.ID?) -> Effect<Action> {
         .run { send in
-            let result = await task({ try await sceneDataFetcher.launchDistrict(districtId: district.id, periodId: periodId) }, defaultError: APIError.unknown(message: "予期しないエラーが発生しました。"))
+            let result = await task({ try await sceneDataFetcher.launchDistrict(districtId: district.id, periodId: periodId) }, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
             switch result {
             case .success(let routeId):
                 await send(.routePrepared(district, routeId))

--- a/iOSApp/Sources/Presentation/View/Public/Map/Root/PublicMapFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Map/Root/PublicMapFeature.swift
@@ -141,7 +141,7 @@ struct PublicMapFeature {
     
     func routeEffect(_ district: District, periodId: Period.ID?) -> Effect<Action> {
         .run { send in
-            let result = await task({ try await sceneDataFetcher.launchDistrict(districtId: district.id, periodId: periodId) }, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
+            let result = await task({ try await sceneDataFetcher.launchDistrict(districtId: district.id, periodId: periodId, clearsExistingData: false) }, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
             switch result {
             case .success(let routeId):
                 await send(.routePrepared(district, routeId))

--- a/iOSApp/Sources/Presentation/View/Public/Map/Route/PublicRouteFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Public/Map/Route/PublicRouteFeature.swift
@@ -64,8 +64,8 @@ struct PublicRouteFeature {
         case locationTapped(FloatEntry)
         case userFocusTapped
         case floatFocusTapped
-        case routeReceived(VoidTaskResult)
-        case locationReceived(VoidTaskResult)
+        case routeReceived(VoidAppResult)
+        case locationReceived(VoidAppResult)
         case userLocationReceived(Coordinate)
         case replayTapped
         case replayEnded
@@ -108,7 +108,7 @@ struct PublicRouteFeature {
                 state.$mapRegion.withLock { $0 = makeRegion(state.points.map(\.coordinate)) }
                 return .none
             case .routeReceived(.failure(let error)):
-                state.alert = AlertFeature.error(error.localizedDescription)
+                state.alert = .error(error)
                 return .none
             case .locationReceived(.success):
                 if let coordinate = state.float?.floatLocation.coordinate {
@@ -116,14 +116,12 @@ struct PublicRouteFeature {
                 }
                 return .none
             case .locationReceived(.failure(let error)):
-                if let error = error as? APIError,
-                    case .notFound = error {
+                if case .be(.notFound) = error {
                     state.alert = AlertFeature.notice("現在地の配信は停止中です。")
-                } else if let error = error as? APIError,
-                    case .forbidden = error {
+                } else if case .be(.forbidden) = error {
                     state.alert = AlertFeature.notice("現在地の配信は停止中です。")
                 } else {
-                    state.alert = AlertFeature.error(error.localizedDescription)
+                    state.alert = .error(error)
                 }
                 return .none
             case .replayTapped:

--- a/iOSApp/Sources/Presentation/View/Shared/AlertFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Shared/AlertFeature.swift
@@ -11,6 +11,10 @@ extension AlertState {
     static func error(_ text: String, title: String = "エラー") -> AlertState<AlertFeature.Action> {
         return AlertFeature.error(text, title: title)
     }
+
+    static func error(_ error: AppError, title: String = "エラー") -> AlertState<AlertFeature.Action> {
+        AlertFeature.error(error.message, title: title)
+    }
     
     static func success(_ text: String, title: String = "完了") -> AlertState<AlertFeature.Action> {
         return AlertFeature.success(text, title: title)

--- a/iOSApp/Sources/Utils/Async.swift
+++ b/iOSApp/Sources/Utils/Async.swift
@@ -119,7 +119,7 @@ func withTimeout<T>(
     }
 }
 
-func task<Value>(_ operation: () async throws -> Value, defaultError: AppError = .system(.unknown("予期しないエラーが発生しました。"))) async -> Result<Value, AppError> {
+func task<Value>(_ operation: () async throws -> Value, defaultError: AppError = .system(.unknown("予期しないエラーが発生しました。"))) async -> AppResult<Value> {
     do {
         let value = try await operation()
         return .success(value)
@@ -133,6 +133,6 @@ func task<Value>(_ operation: () async throws -> Value, defaultError: AppError =
 }
 
 func task(_ operation: () async throws -> Void) async -> VoidAppResult {
-    let result: Result<Void, AppError> = await task(operation, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
+    let result: AppResult<Void> = await task(operation, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
     return result.map{ VoidSuccess() }
 }

--- a/iOSApp/Sources/Utils/Async.swift
+++ b/iOSApp/Sources/Utils/Async.swift
@@ -85,7 +85,7 @@ extension AsyncValue: Equatable where T: Equatable {
         case (.loading, .loading):
             return true
         case (.failure(let lhsError), .failure(let rhsError)):
-            return lhsError.localizedDescription == rhsError.localizedDescription // エラーの比較
+            return lhsError.asAppError == rhsError.asAppError
         case (.success(let lhsValue), .success(let rhsValue)):
             return lhsValue == rhsValue
         default:
@@ -107,7 +107,7 @@ func withTimeout<T>(
             try await Task.sleep(
                 nanoseconds: UInt64(seconds) * 1_000_000_000
             )
-            throw AuthError.timeout("タイムアウトしました")
+            throw AppError.auth(.timeout("タイムアウトしました"))
         }
 
         guard let result = try await group.next() else {
@@ -119,19 +119,20 @@ func withTimeout<T>(
     }
 }
 
-func task<Value, Error: Swift.Error>(_ operation: () async throws -> Value, defaultError: Error) async -> Result<Value, Error> {
+func task<Value>(_ operation: () async throws -> Value, defaultError: AppError = .system(.unknown("予期しないエラーが発生しました。"))) async -> Result<Value, AppError> {
     do {
         let value = try await operation()
         return .success(value)
     } catch {
-        guard let error = error as? Error else {
+        let appError = error.asAppError
+        if case .system(.unexpected) = appError {
             return .failure(defaultError)
         }
-        return .failure(error)
+        return .failure(appError)
     }
 }
 
-func task(_ operation: () async throws -> Void) async -> VoidResult<APIError> {
-    let result: Result<Void, APIError> = await task(operation, defaultError: APIError.unknown(message: "予期しないエラーが発生しました"))
+func task(_ operation: () async throws -> Void) async -> VoidAppResult {
+    let result: Result<Void, AppError> = await task(operation, defaultError: .system(.unknown("予期しないエラーが発生しました。")))
     return result.map{ VoidSuccess() }
 }

--- a/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
+++ b/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
@@ -13,6 +13,7 @@ struct VoidSuccess: Equatable {
 
 typealias VoidResult<Failure: Swift.Error> = Result<VoidSuccess, Failure>
 typealias VoidAppResult = VoidResult<AppError>
+typealias AppResult<Success> = Result<Success, AppError>
 
 extension VoidResult where Success == VoidSuccess {
     static var success: Self {
@@ -21,7 +22,7 @@ extension VoidResult where Success == VoidSuccess {
 }
 
 extension Effect {
-    static func task<Success>(_ action: @escaping (Result<Success, AppError>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
+    static func task<Success>(_ action: @escaping (AppResult<Success>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
         return Self.run { send in
             do {
                 let value = try await operation()

--- a/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
+++ b/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
@@ -12,6 +12,7 @@ struct VoidSuccess: Equatable {
 }
 
 typealias VoidResult<Failure: Swift.Error> = Result<VoidSuccess, Failure>
+typealias VoidAppResult = VoidResult<AppError>
 
 extension VoidResult where Success == VoidSuccess {
     static var success: Self {
@@ -19,41 +20,26 @@ extension VoidResult where Success == VoidSuccess {
     }
 }
 
-typealias VoidTaskResult = Result<VoidSuccess, Error>
-
-extension TaskResult where Success == VoidSuccess {
-    init(catching body: @Sendable () async throws -> Void) async {
-        do {
-            try await body()
-            self = .success(VoidSuccess())
-        } catch {
-            self = .failure(error)
-        }
-    }
-}
-
 extension Effect {
-    static func task<Success>(_ action: @escaping (Result<Success, Error>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
+    static func task<Success>(_ action: @escaping (Result<Success, AppError>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
         return Self.run { send in
-            await send(
-                action(
-                    Result{
-                        try await operation()
-                    }
-                )
-            )
+            do {
+                let value = try await operation()
+                await send(action(.success(value)))
+            } catch {
+                await send(action(.failure(error.asAppError)))
+            }
         }
     }
     
-    static func task(_ action: @escaping (VoidTaskResult) -> Action, operation: @escaping @Sendable () async throws -> Void) -> Self {
+    static func task(_ action: @escaping (VoidAppResult) -> Action, operation: @escaping @Sendable () async throws -> Void) -> Self {
         return Self.run { send in
-            await send(
-                action(
-                    VoidTaskResult {
-                        try await operation()
-                    }
-                )
-            )
+            do {
+                try await operation()
+                await send(action(.success))
+            } catch {
+                await send(action(.failure(error.asAppError)))
+            }
         }
     }
 }

--- a/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
+++ b/iOSApp/Sources/Utils/ComposableArchitecture+TaskResult.swift
@@ -19,7 +19,7 @@ extension VoidResult where Success == VoidSuccess {
     }
 }
 
-typealias VoidTaskResult = TaskResult<VoidSuccess>
+typealias VoidTaskResult = Result<VoidSuccess, Error>
 
 extension TaskResult where Success == VoidSuccess {
     init(catching body: @Sendable () async throws -> Void) async {
@@ -33,11 +33,11 @@ extension TaskResult where Success == VoidSuccess {
 }
 
 extension Effect {
-    static func task<Success>(_ action: @escaping (TaskResult<Success>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
+    static func task<Success>(_ action: @escaping (Result<Success, Error>) -> Action, operation: @escaping @Sendable () async throws -> Success ) -> Self {
         return Self.run { send in
             await send(
                 action(
-                    TaskResult {
+                    Result{
                         try await operation()
                     }
                 )

--- a/iOSApp/Sources/Utils/PresentationError.swift
+++ b/iOSApp/Sources/Utils/PresentationError.swift
@@ -7,4 +7,11 @@
 
 enum PresentationError: Error{
     case notFound
+
+    var appError: AppError {
+        switch self {
+        case .notFound:
+            return .export(.notFound("必要な情報の取得に失敗しました。"))
+        }
+    }
 }

--- a/iOSApp/Tests/Data/AuthProviderMock.swift
+++ b/iOSApp/Tests/Data/AuthProviderMock.swift
@@ -29,7 +29,7 @@ extension AuthProvider {
             return .district("祭_町")
         },
         getTokens: {
-            throw AuthError.unknown("Mock")
+            throw AppError.auth(.unknown("Mock"))
         },
         signOut: {
             return ()


### PR DESCRIPTION
## 目的\nTaskResult を廃止し、Result<AppError> に統一してエラーの比較と表示を安定させる。\n\n## 変更点\n- AppError を発生源ベースの親 enum と小分類 enum で再設計\n- TaskResult / VoidTaskResult を廃止し、Result / VoidAppResult に置換\n- HTTPClient / AuthProvider / SceneUsecase / LocationService / RouteSnapshotter を AppError へ正規化\n- Feature 側の alert 表示を AppError ベースへ更新\n- iOSApp の xcodeproj 依存定義を更新\n\n## 動作確認\n- iOSApp を Simulator で build 成功\n- iOSApp を Simulator で launch 成功\n\n## 影響範囲\n- iOSApp の非同期 action / alert 表示 / エラー変換\n\n## 補足\n- 既存の xcshareddata の未追跡差分は PR に含めていません。