### PR TITLE
iOS: 管理画面の地区一覧で最新ルートを取得

### DIFF
--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
@@ -66,7 +66,7 @@ struct HeadquarterDistrictListFeature {
                 state.isLoading = true
                 return .task(Action.selectedReceived) {
                     async let districtFetch: Void = dataFetcher.fetch(districtID: district.id)
-                    async let routeFetch: Void = routeDataFetcher.fetchAll(districtID: district.id, query: .year(2025))
+                    async let routeFetch: Void = routeDataFetcher.fetchAll(districtID: district.id, query: .latest)
                     _ = try await (districtFetch, routeFetch)
                     return district
                 }


### PR DESCRIPTION
## 目的
地区一覧画面で、固定年ではなく最新のルートを取得するため。

## 変更点
- `HeadquarterDistrictListFeature` の `routeDataFetcher.fetchAll` を `.year(2025)` から `.latest` に変更

## 動作確認
- `./.codex/skills/matool-build-test/scripts/safe_build_test.sh ios-run` を実行したが、CoreSimulatorService / Simulator 起動エラーで失敗
- `./.codex/skills/matool-build-test/scripts/safe_build_test.sh ios-build` を実行したが、同じく Simulator 周りの環境エラーと `MaTool.xcworkspace` 認識エラーで失敗

## 影響範囲・リスク
- 取得対象が最新データに変わるため、表示内容が年固定時と変わる可能性あり