### PR TITLE
iOS: 詳細画面のルート修正を一時保持

### DIFF
--- a/MaTool.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MaTool.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,465 @@
+{
+  "originHash" : "9ca5c42b47c92991b8ca35da13bdfb0837c84e481179b56b8df9ca17492e44ef",
+  "pins" : [
+    {
+      "identity" : "amplify-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-ios.git",
+      "state" : {
+        "revision" : "4a75795527db509b5fd52d7096b95f8f76869477",
+        "version" : "2.57.0"
+      }
+    },
+    {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "959eec669ba97c7d923b963c3e66ca8a0b2737f6",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "aws-crt-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-crt-swift",
+      "state" : {
+        "revision" : "d754d289d594adc240f55c90eab212bac818509c",
+        "version" : "0.58.1"
+      }
+    },
+    {
+      "identity" : "aws-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-sdk-swift.git",
+      "state" : {
+        "revision" : "6518f3491768180ff4c89f5c6425c4fc04713772",
+        "version" : "1.6.71"
+      }
+    },
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "c152c1915f60c51e4afa0752656993ee5b3c63db",
+        "version" : "8.8.1"
+      }
+    },
+    {
+      "identity" : "navigationswipecontrol",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kmatsushita1012/NavigationSwipeControl.git",
+      "state" : {
+        "revision" : "3f0348c7fc4923dc3daf433d61562338e3703c23",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "smithy-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
+      "state" : {
+        "revision" : "60bc71892ac8c206df0cc2e14c987455d45ace68",
+        "version" : "0.191.0"
+      }
+    },
+    {
+      "identity" : "sqlite-data",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/sqlite-data.git",
+      "state" : {
+        "revision" : "0c79d7a5748fc6d9ce7a1ba2b50f31b175305049",
+        "version" : "1.6.6"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "392dd6058624d9f6c5b4c769d165ddd8c7293394",
+        "version" : "0.15.4"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-aws-lambda-events",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-aws-lambda-events.git",
+      "state" : {
+        "revision" : "d18360e63624019bddf418de28d83007acd60956",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-aws-lambda-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/swift-aws-lambda-runtime.git",
+      "state" : {
+        "revision" : "553b5e3716ef8e922e57b6f271248a808d23d0fb",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths.git",
+      "state" : {
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-dotenv",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/thebarndog/swift-dotenv.git",
+      "state" : {
+        "revision" : "d13062940a3cdb2b13efa22ecc83b07b21c2e8dc",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
+        "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-structured-queries",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-structured-queries",
+      "state" : {
+        "revision" : "b59f4424b9050739ac7c2d82e80edf5e6dbb19e8",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "swift-toolchain-sqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
+      "state" : {
+        "revision" : "b626d3002773b1a1304166643e7f118f724b2132",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/iOSApp/Sources/Domain/Entry/RouteDraft.swift
+++ b/iOSApp/Sources/Domain/Entry/RouteDraft.swift
@@ -1,0 +1,18 @@
+//
+//  RouteDraft.swift
+//  MaTool
+//
+//  Created by OpenAI Codex on 2026/06/19.
+//
+
+import Shared
+
+struct RouteDraft: Equatable, Sendable, Identifiable {
+    var route: Route
+    var points: [Point]
+    var passages: [RoutePassage]
+
+    var id: Route.ID {
+        route.id
+    }
+}

--- a/iOSApp/Sources/Presentation/Parts/Row/RouteSlotView.swift
+++ b/iOSApp/Sources/Presentation/Parts/Row/RouteSlotView.swift
@@ -9,14 +9,16 @@ import SwiftUI
 
 struct RouteSlotView: View {
     let item: RouteSlot
+    let statusText: String
     var onTap: (() -> Void)? = nil
     
     var status: String {
-        item.route != nil ? "作成済" : "未作成"
+        statusText
     }
     
-    init(_ item: RouteSlot, onTap: (() -> Void)? = nil) {
+    init(_ item: RouteSlot, statusText: String? = nil, onTap: (() -> Void)? = nil) {
         self.item = item
+        self.statusText = statusText ?? (item.route != nil ? "作成済" : "未作成")
         self.onTap = onTap
     }
     

--- a/iOSApp/Sources/Presentation/Utils/PDFRenderer.swift
+++ b/iOSApp/Sources/Presentation/Utils/PDFRenderer.swift
@@ -42,6 +42,7 @@ struct ActionTableSnapshotter: Sendable {
 
     private let district: District
     private let slots: [RouteSlot]
+    private let passagesByRouteID: [Route.ID: [RoutePassage]]
     private let linesPerPeriod = 5
     private let columnsPerLine = 5
     private let pageLift: CGFloat = -48
@@ -50,9 +51,10 @@ struct ActionTableSnapshotter: Sendable {
     private let rowFontSize: CGFloat = 15
     private let arrowFontSize: CGFloat = 16
 
-    init(district: District, slots: [RouteSlot]) {
+    init(district: District, slots: [RouteSlot], passagesByRouteID: [Route.ID: [RoutePassage]] = [:]) {
         self.district = district
         self.slots = slots
+        self.passagesByRouteID = passagesByRouteID
     }
 
     func takeAll() -> [UIImage] {
@@ -247,7 +249,7 @@ struct ActionTableSnapshotter: Sendable {
         daySlots.map { slot in
             let entries: [String] = {
                 guard let route = slot.route else { return [] }
-                let passages:[RoutePassage] = FetchAll(routeId: route.id).wrappedValue
+                let passages: [RoutePassage] = passagesByRouteID[route.id] ?? FetchAll(routeId: route.id).wrappedValue
                 return passages.prefix(linesPerPeriod * columnsPerLine).map(passageTitle)
             }()
             return Row(

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -33,10 +33,6 @@ struct RouteSnapshotter: Equatable {
         self.route = route
         self.points = points
         self.hazardSections = FetchAll(festivalId: district.festivalId).wrappedValue
-        print("[RouteSnapshotter] route=\(route.id) district=\(district.id) festival=\(district.festivalId) points=\(points.count) hazardSections=\(hazardSections.count)")
-        for section in hazardSections {
-            print("[RouteSnapshotter] hazard id=\(section.id) title=\(section.title) coords=\(section.coordinates.count)")
-        }
     }
     
     private var coordinates: [Coordinate] {
@@ -91,10 +87,11 @@ struct RouteSnapshotter: Equatable {
                         UIGraphicsEndImageContext()
                     }
                     snapshot.image.draw(at: .zero)
+                    drawHazardSectionPolylines(on: snapshot)
                     drawPolylines(on: snapshot, color: .white, lineWidth: 4)
                     drawBoundaryPolylines(on: snapshot, lineWidth: 3)
                     drawPinsAndCaptions(on: snapshot, drawnRects: &drawnRects)
-                    drawHazardSectionPolylines(on: snapshot)
+                    
                     drawHazardSectionCaptions(on: snapshot, drawnRects: &drawnRects)
                     
                     let titleText = """
@@ -340,7 +337,6 @@ struct RouteSnapshotter: Equatable {
 
             let labelCoordinate = coordinates[coordinates.count / 2]
             let point = snapshot.point(for: labelCoordinate.toCL())
-            print("[RouteSnapshotter] draw caption id=\(section.id) title=\(section.title) label=\(labelCoordinate.latitude),\(labelCoordinate.longitude) point=\(point.x),\(point.y)")
             drawCaption(for: section.title, at: point, pinImage: pinImage, drawnRects: &drawnRects)
         }
     }
@@ -349,7 +345,6 @@ struct RouteSnapshotter: Equatable {
         for section in hazardSections {
             let coordinates = section.coordinates
             guard coordinates.count > 1 else { continue }
-            print("[RouteSnapshotter] draw polyline id=\(section.id) coords=\(coordinates.count)")
             drawPolyline(on: snapshot, coordinates: coordinates, color: .orange, lineWidth: 8)
         }
     }

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -33,6 +33,10 @@ struct RouteSnapshotter: Equatable {
         self.route = route
         self.points = points
         self.hazardSections = FetchAll(festivalId: district.festivalId).wrappedValue
+        print("[RouteSnapshotter] route=\(route.id) district=\(district.id) festival=\(district.festivalId) points=\(points.count) hazardSections=\(hazardSections.count)")
+        for section in hazardSections {
+            print("[RouteSnapshotter] hazard id=\(section.id) title=\(section.title) coords=\(section.coordinates.count)")
+        }
     }
     
     private var coordinates: [Coordinate] {
@@ -87,11 +91,10 @@ struct RouteSnapshotter: Equatable {
                         UIGraphicsEndImageContext()
                     }
                     snapshot.image.draw(at: .zero)
-                    drawHazardSectionPolylines(on: snapshot)
                     drawPolylines(on: snapshot, color: .white, lineWidth: 4)
                     drawBoundaryPolylines(on: snapshot, lineWidth: 3)
                     drawPinsAndCaptions(on: snapshot, drawnRects: &drawnRects)
-                    
+                    drawHazardSectionPolylines(on: snapshot)
                     drawHazardSectionCaptions(on: snapshot, drawnRects: &drawnRects)
                     
                     let titleText = """
@@ -337,6 +340,7 @@ struct RouteSnapshotter: Equatable {
 
             let labelCoordinate = coordinates[coordinates.count / 2]
             let point = snapshot.point(for: labelCoordinate.toCL())
+            print("[RouteSnapshotter] draw caption id=\(section.id) title=\(section.title) label=\(labelCoordinate.latitude),\(labelCoordinate.longitude) point=\(point.x),\(point.y)")
             drawCaption(for: section.title, at: point, pinImage: pinImage, drawnRects: &drawnRects)
         }
     }
@@ -345,6 +349,7 @@ struct RouteSnapshotter: Equatable {
         for section in hazardSections {
             let coordinates = section.coordinates
             guard coordinates.count > 1 else { continue }
+            print("[RouteSnapshotter] draw polyline id=\(section.id) coords=\(coordinates.count)")
             drawPolyline(on: snapshot, coordinates: coordinates, color: .orange, lineWidth: 8)
         }
     }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -79,7 +79,7 @@ struct RouteEditFeature{
         case undoTapped
         case redoTapped
         case saveTapped
-        case modified
+        case modified(VoidAppResult)
         case cancelTapped
         case deleteTapped
         case wholeTapped
@@ -156,8 +156,7 @@ struct RouteEditFeature{
                 }
                 switch state.mode {
                 case .preview:
-                    return .run { send in
-                        await send(.modified)
+                    return .task(Action.modified) {
                         await dismiss()
                     }
                 case .create, .update:
@@ -174,7 +173,10 @@ struct RouteEditFeature{
                         await dismiss()
                     }
                 }
-            case .modified:
+            case .modified(.success):
+                return .none
+            case .modified(.failure(let error)):
+                state.alert = .notice(.error(error.localizedDescription))
                 return .none
             case .cancelTapped:
                 return .dismiss

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -71,6 +71,10 @@ struct RouteEditFeature{
     
     @CasePathable
     enum Action: Equatable, BindableAction{
+        enum Delegate: Equatable {
+            case applied(RouteDraft)
+        }
+
         case binding(BindingAction<State>)
         case onAppear
         case mapLongPressed(Coordinate)
@@ -95,6 +99,7 @@ struct RouteEditFeature{
         case copyPrepared(AppResult<Route.ID>)
         case deleteReceived(VoidAppResult)
         case previewPrepared(AppResult<ExportedItem>)
+        case delegate(Delegate)
         case point(PresentationAction<PointEditFeature.Action>)
         case alert(PresentationAction<AlertDestination.Action>)
     }
@@ -107,7 +112,7 @@ struct RouteEditFeature{
         Reduce{ state, action in
             switch action {
             case .onAppear:
-                if !state.district.isEditable && state.isSaveable {
+                if !state.district.isEditable && state.mode != .preview {
                     state.alert = .notice(.notice("\(state.festival.subname)がルートの更新を停止しています。"))
                 }
                 return .none
@@ -147,18 +152,32 @@ struct RouteEditFeature{
                 state.operation = .add
                 return .none
             case .saveTapped:
-                state.isLoading = true
-                return .task(Action.saveReceived) {[state] in
+                do {
                     try state.points.validate()
-                    switch state.mode {
-                    case .create:
-                        try await dataFetcher.create(districtID: state.route.districtId, route: state.route, points: state.points, passages: state.passages)
-                    case .update:
-                        try await dataFetcher.update(state.route, points: state.points, passages: state.passages)
-                    case .preview:
-                        throw AppError.be(.forbidden("権限がありません"))
+                } catch {
+                    state.alert = .notice(.error(error.localizedDescription))
+                    return .none
+                }
+                switch state.mode {
+                case .preview:
+                    let draft = RouteDraft(route: state.route, points: state.points, passages: state.passages)
+                    return .run { send in
+                        await send(.delegate(.applied(draft)))
+                        await dismiss()
                     }
-                    await dismiss()
+                case .create, .update:
+                    state.isLoading = true
+                    return .task(Action.saveReceived) {[state] in
+                        switch state.mode {
+                        case .create:
+                            try await dataFetcher.create(districtID: state.route.districtId, route: state.route, points: state.points, passages: state.passages)
+                        case .update:
+                            try await dataFetcher.update(state.route, points: state.points, passages: state.passages)
+                        case .preview:
+                            throw AppError.be(.forbidden("権限がありません"))
+                        }
+                        await dismiss()
+                    }
                 }
             case .cancelTapped:
                 return .dismiss
@@ -318,9 +337,18 @@ extension RouteEditFeature.State {
     var canUndo: Bool { manager.canUndo }
     var canRedo: Bool{ manager.canRedo }
     var isSaveable: Bool { mode != .preview }
+    var isConfirmDisabled: Bool { false }
     var isDeleteable: Bool { mode == .update}
     var isPartialEnable: Bool { tab != .info }
     var isAutoPassageDisabled: Bool { points.count < 2 }
+    var saveButtonTitle: String {
+        switch mode {
+        case .preview:
+            return "修正"
+        case .create, .update:
+            return "保存"
+        }
+    }
     var title: String {
         switch mode {
         case .create:
@@ -354,13 +382,18 @@ extension RouteEditFeature.State {
     }
     
     init(mode: RouteEditFeature.EditMode, route: Route) throws {
-        self.mode = mode
         let points: [Point] = FetchAll(routeId: route.id).wrappedValue
-        self.manager = EditManager(points.sorted())
-        self.passages = FetchAll(routeId: route.id).wrappedValue
-        self.route = route
-        guard let districtQuery: FetchOne<District> = .init(id: route.districtId),
-            let periodQuery: FetchOne<Period> = .init(id: route.periodId),
+        let passages: [RoutePassage] = FetchAll(routeId: route.id).wrappedValue
+        try self.init(mode: mode, draft: RouteDraft(route: route, points: points, passages: passages))
+    }
+
+    init(mode: RouteEditFeature.EditMode, draft: RouteDraft) throws {
+        self.mode = mode
+        self.manager = EditManager(draft.points.sorted())
+        self.passages = draft.passages
+        self.route = draft.route
+        guard let districtQuery: FetchOne<District> = .init(id: draft.route.districtId),
+            let periodQuery: FetchOne<Period> = .init(id: draft.route.periodId),
             let festivalQuery: FetchOne<Festival> = .init(id: districtQuery.wrappedValue.festivalId) else {
             throw PresentationError.notFound
         }
@@ -370,8 +403,8 @@ extension RouteEditFeature.State {
         
         let origin: Coordinate = districtQuery.wrappedValue.base ?? festivalQuery.wrappedValue.base
 
-        self.region = makeRegion(points: points, origin: origin, spanDelta: spanDelta)
-            self.tab = .info
+        self.region = makeRegion(points: draft.points, origin: origin, spanDelta: spanDelta)
+        self.tab = .info
     }
 }
 

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -71,10 +71,6 @@ struct RouteEditFeature{
     
     @CasePathable
     enum Action: Equatable, BindableAction{
-        enum Delegate: Equatable {
-            case applied(RouteDraft)
-        }
-
         case binding(BindingAction<State>)
         case onAppear
         case mapLongPressed(Coordinate)
@@ -83,6 +79,7 @@ struct RouteEditFeature{
         case undoTapped
         case redoTapped
         case saveTapped
+        case modified
         case cancelTapped
         case deleteTapped
         case wholeTapped
@@ -99,7 +96,6 @@ struct RouteEditFeature{
         case copyPrepared(AppResult<Route.ID>)
         case deleteReceived(VoidAppResult)
         case previewPrepared(AppResult<ExportedItem>)
-        case delegate(Delegate)
         case point(PresentationAction<PointEditFeature.Action>)
         case alert(PresentationAction<AlertDestination.Action>)
     }
@@ -160,9 +156,8 @@ struct RouteEditFeature{
                 }
                 switch state.mode {
                 case .preview:
-                    let draft = RouteDraft(route: state.route, points: state.points, passages: state.passages)
                     return .run { send in
-                        await send(.delegate(.applied(draft)))
+                        await send(.modified)
                         await dismiss()
                     }
                 case .create, .update:
@@ -179,6 +174,8 @@ struct RouteEditFeature{
                         await dismiss()
                     }
                 }
+            case .modified:
+                return .none
             case .cancelTapped:
                 return .dismiss
             case .deleteTapped:

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
@@ -69,7 +69,7 @@ struct RouteEditView: View {
     
     @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
-        ToolbarSaveButton(isDisabled: !store.isSaveable){
+        ToolbarSaveButton(title: store.saveButtonTitle, isDisabled: store.isConfirmDisabled){
             store.send(.saveTapped)
         }
         ToolbarCancelButton {

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -23,7 +23,6 @@ struct HeadquarterDistrictDetailFeature {
     struct State: Equatable {
         var district: District
         var routes: [RouteSlot]
-        fileprivate var originalRoutes: [Route.ID: Route] = [:]
         var routeDrafts: [Route.ID: RouteDraft] = [:]
         
         var isEditable: Bool = false
@@ -94,14 +93,8 @@ struct HeadquarterDistrictDetailFeature {
                 return exportEffect(state: state, path: "\(state.district.name)_行動表.pdf", includesRouteMap: false)
             case .resetDraftsTapped:
                 guard !state.routeDrafts.isEmpty else { return .none }
-                let draftIDs = Set(state.routeDrafts.keys)
                 state.routeDrafts = [:]
-                for index in state.routes.indices {
-                    guard let route = state.routes[index].route,
-                          draftIDs.contains(route.id),
-                          let originalRoute = state.originalRoutes[route.id] else { continue }
-                    state.routes[index] = RouteSlot(period: state.routes[index].period, route: originalRoute)
-                }
+                state.routes = FetchAll(districtId: state.district.id, latest: true).wrappedValue
                 return .none
             case .updateReceived(.success):
                 state.isLoading = false
@@ -203,10 +196,6 @@ extension HeadquarterDistrictDetailFeature.State {
         let routes: [RouteSlot] = FetchAll(districtId: district.id, latest: true).wrappedValue
         self.district = district
         self.routes = routes
-        self.originalRoutes = Dictionary(uniqueKeysWithValues: routes.compactMap {
-            guard let route = $0.route else { return nil }
-            return (route.id, route)
-        })
     }
     
 }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -23,7 +23,7 @@ struct HeadquarterDistrictDetailFeature {
     struct State: Equatable {
         var district: District
         var routes: [RouteSlot]
-        var originalRoutes: [Route.ID: Route] = [:]
+        fileprivate var originalRoutes: [Route.ID: Route] = [:]
         var routeDrafts: [Route.ID: RouteDraft] = [:]
         
         var isEditable: Bool = false

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -22,7 +22,9 @@ struct HeadquarterDistrictDetailFeature {
     @ObservableState
     struct State: Equatable {
         var district: District
-        @FetchAll var routes: [RouteSlot]
+        var routes: [RouteSlot]
+        var originalRoutes: [Route.ID: Route] = [:]
+        var routeDrafts: [Route.ID: RouteDraft] = [:]
         
         var isEditable: Bool = false
         var isLoading: Bool = false
@@ -38,6 +40,7 @@ struct HeadquarterDistrictDetailFeature {
         case editTapped
         case reissueTapped
         case routeSelected(RouteSlot)
+        case resetDraftsTapped
         case batchExportTapped
         case tableExportTapped
         case updateReceived(VoidAppResult)
@@ -73,6 +76,10 @@ struct HeadquarterDistrictDetailFeature {
                 return .none
             case .routeSelected(let slot):
                 guard let route = slot.route else { return .none }
+                if let draft = state.routeDrafts[route.id] {
+                    state.destination = try? { .route(try .init(mode: .preview, draft: draft)) }()
+                    return .none
+                }
                 state.isLoading = true
                 let entry: RouteEntry = .init(period: slot.period, route: route)
                 return .task(Action.routeReceived) {
@@ -85,12 +92,30 @@ struct HeadquarterDistrictDetailFeature {
             case .tableExportTapped:
                 state.isLoading = true
                 return exportEffect(state: state, path: "\(state.district.name)_行動表.pdf", includesRouteMap: false)
+            case .resetDraftsTapped:
+                guard !state.routeDrafts.isEmpty else { return .none }
+                let draftIDs = Set(state.routeDrafts.keys)
+                state.routeDrafts = [:]
+                for index in state.routes.indices {
+                    guard let route = state.routes[index].route,
+                          draftIDs.contains(route.id),
+                          let originalRoute = state.originalRoutes[route.id] else { continue }
+                    state.routes[index] = RouteSlot(period: state.routes[index].period, route: originalRoute)
+                }
+                return .none
             case .updateReceived(.success):
                 state.isLoading = false
                 return .none
             case .routeReceived(.success(let entry)):
                 state.isLoading = false
                 state.destination = try? { .route(try .init(mode: .preview, route: entry.route)) }()
+                return .none
+            case .destination(.presented(.route(.delegate(.applied(let draft))))):
+                state.routeDrafts[draft.route.id] = draft
+                if let index = state.routes.firstIndex(where: { $0.route?.id == draft.route.id }) {
+                    let slot = state.routes[index]
+                    state.routes[index] = RouteSlot(period: slot.period, route: draft.route)
+                }
                 return .none
             case .batchExportReceived(.success(let url)):
                 state.isLoading = false
@@ -117,14 +142,32 @@ struct HeadquarterDistrictDetailFeature {
             //非同期並列にするとBEでアクセス過多
             let renderer = await PDFRenderer(path: path)
             let routes = state.routes.compactMap(\.route)
+            var passagesByRouteID: [Route.ID: [RoutePassage]] = [:]
+            var pointsByRouteID: [Route.ID: [Point]] = [:]
+            var resolvedRoutesByRouteID: [Route.ID: Route] = [:]
             for route in routes {
+                if let draft = state.routeDrafts[route.id] {
+                    passagesByRouteID[route.id] = draft.passages
+                    pointsByRouteID[route.id] = draft.points
+                    resolvedRoutesByRouteID[route.id] = draft.route
+                    continue
+                }
                 do {
                     try await routeDataFetcher.fetch(routeID: route.id)
+                    let passages: [RoutePassage] = FetchAll(routeId: route.id).wrappedValue
+                    let points: [Point] = FetchAll(routeId: route.id).wrappedValue
+                    passagesByRouteID[route.id] = passages
+                    pointsByRouteID[route.id] = points
+                    resolvedRoutesByRouteID[route.id] = route
                 } catch {
                     continue
                 }
             }
-            let tableSnapshotter = await ActionTableSnapshotter(district: state.district, slots: state.routes)
+            let tableSnapshotter = await ActionTableSnapshotter(
+                district: state.district,
+                slots: state.routes,
+                passagesByRouteID: passagesByRouteID
+            )
             let tablePages = await tableSnapshotter.takeAll()
             for page in tablePages {
                 await renderer.addPage(with: page)
@@ -134,7 +177,9 @@ struct HeadquarterDistrictDetailFeature {
                 return url
             }
             for route in routes {
-                guard let snapshotter = try? await RouteSnapshotter(route),
+                let resolvedRoute = resolvedRoutesByRouteID[route.id] ?? route
+                guard let points = pointsByRouteID[route.id],
+                      let snapshotter = try? await RouteSnapshotter(route: resolvedRoute, points: points),
                       let image = try? await snapshotter.take() else { continue }
                 await renderer.addPage(with: image)
             }
@@ -149,8 +194,13 @@ extension HeadquarterDistrictDetailFeature.Destination.Action: Equatable {}
 
 extension HeadquarterDistrictDetailFeature.State {
     init(_ district: District) {
+        let routes: [RouteSlot] = FetchAll(districtId: district.id, latest: true).wrappedValue
         self.district = district
-        self._routes = FetchAll(districtId: district.id, latest: true)
+        self.routes = routes
+        self.originalRoutes = Dictionary(uniqueKeysWithValues: routes.compactMap {
+            guard let route = $0.route else { return nil }
+            return (route.id, route)
+        })
     }
     
 }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -110,7 +110,7 @@ struct HeadquarterDistrictDetailFeature {
                 state.isLoading = false
                 state.destination = try? { .route(try .init(mode: .preview, route: entry.route)) }()
                 return .none
-            case .destination(.presented(.route(.modified))):
+            case .destination(.presented(.route(.modified(.success)))):
                 guard let routeState = state.destination?.route else { return .none }
                 let draft = RouteDraft(
                     route: routeState.route,

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -110,7 +110,13 @@ struct HeadquarterDistrictDetailFeature {
                 state.isLoading = false
                 state.destination = try? { .route(try .init(mode: .preview, route: entry.route)) }()
                 return .none
-            case .destination(.presented(.route(.delegate(.applied(let draft))))):
+            case .destination(.presented(.route(.modified))):
+                guard let routeState = state.destination?.route else { return .none }
+                let draft = RouteDraft(
+                    route: routeState.route,
+                    points: routeState.points,
+                    passages: routeState.passages
+                )
                 state.routeDrafts[draft.route.id] = draft
                 if let index = state.routes.firstIndex(where: { $0.route?.id == draft.route.id }) {
                     let slot = state.routes[index]

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailView.swift
@@ -34,10 +34,22 @@ struct HeadquarterDistrictDetailView: View {
             .disabled(!store.isEditable)
             Section(header: Text("ルート")) {
                 ForEach(store.routes) { pair in
-                    RouteSlotView(pair){
+                    let statusText: String? = {
+                        guard let route = pair.route,
+                              store.routeDrafts[route.id] != nil else { return nil }
+                        return "修正済"
+                    }()
+                    RouteSlotView(
+                        pair,
+                        statusText: statusText
+                    ) {
                         store.send(.routeSelected(pair))
                     }
                 }
+                Button("修正をリセット") {
+                    store.send(.resetDraftsTapped)
+                }
+                .disabled(store.routeDrafts.isEmpty)
             }
             Section {
                 Button(action: {


### PR DESCRIPTION
## 背景
本部権限の詳細画面でルート修正を行ったとき、画面を離れると編集内容が棄却される一方で、画面内の表示や提出資料出力には編集結果を反映したい、という要件に合わせた修正です。

## 仕様
- 修正内容は `HeadquarterDistrictDetailFeature` の中だけで保持し、`HeadquarterDistrictListFeature` には伝播させません。
- 画面を離れたら修正内容は破棄します。永続化は行いません。
- `RouteSlot` は `State` 初期化時に `wrappedValue` から受け取り、`State` 側は mutable にして画面内で原本と修正済みを切り替えます。
- ルート全体の取得は従来通りオンデマンドです。必要になったタイミングでのみ取得します。
- 提出資料出力は、修正済みのローカル状態がある場合はそれを使い、なければ原本を使います。

## 画面仕様
- `HeadquarterDistrictDetailView.swift` の slot 表記は、修正が入っている場合に `修正済` と表示します。
- ルートセクションの最下部に `修正をリセット` ボタンを追加し、押下時はその画面内で保持している修正内容を破棄して原本に戻します。
- リセット後は、画面内表示と提出資料出力の両方が原本基準に戻ります。

## 実装範囲
- 変更は詳細画面の feature / view / export 周辺に閉じています。
- List 側には修正状態を持ち込みません。

## 確認
- iPhone 17 / iOS 26.5 simulator で build 確認済みです。
