### PR TITLE
shared: 曜日計算を日本時間のグレゴリオ暦に固定

### DIFF
--- a/Shared/Sources/Entity/DateTime.swift
+++ b/Shared/Sources/Entity/DateTime.swift
@@ -8,6 +8,16 @@
 import Foundation
 
 private let japanTimeZone: TimeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+private let japanLocale = Locale(identifier: "ja_JP")
+
+public extension Calendar {
+    static var japanGregorian: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = japanTimeZone
+        calendar.locale = japanLocale
+        return calendar
+    }
+}
 
 // MARK: - SimpleDate
 public struct SimpleDate: Entity {
@@ -22,8 +32,7 @@ public struct SimpleDate: Entity {
     }
     
     public var isValid: Bool {
-        var cal = Calendar.current
-        cal.timeZone = japanTimeZone
+        let cal = Calendar.japanGregorian
         var comps = DateComponents()
         comps.year = year
         comps.month = month
@@ -85,8 +94,7 @@ public extension SimpleTime {
 // MARK: - Extension
 public extension SimpleDate {
     var toDate: Date {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         var components = DateComponents()
         components.year = year
         components.month = month
@@ -98,8 +106,7 @@ public extension SimpleDate {
     }
     
     static func from(_ date: Date) -> SimpleDate {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         let comps = calendar.dateComponents([.year, .month, .day], from: date)
         return SimpleDate(year: comps.year ?? 1970, month: comps.month ?? 1, day: comps.day ?? 1)
     }
@@ -110,16 +117,14 @@ public extension SimpleDate {
     
     /// 曜日 (1=日曜, 2=月曜 ... 7=土曜)
     var weekday: Int {
-        var cal = Calendar.current
-        cal.timeZone = japanTimeZone
+        let cal = Calendar.japanGregorian
         return cal.component(.weekday, from: toDate)
     }
 }
 
 public extension SimpleTime {
     var toDate: Date {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         let now = Date()
         var components = calendar.dateComponents([.year, .month, .day], from: now)
         components.hour = hour
@@ -129,8 +134,7 @@ public extension SimpleTime {
     }
     
     static func from(_ date: Date) -> SimpleTime {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         let components = calendar.dateComponents([.hour, .minute], from: date)
         return SimpleTime(hour: components.hour ?? 0, minute: components.minute ?? 0)
     }
@@ -146,8 +150,7 @@ public extension Date {
     }
     
     static func theDayAt(date: Date, hour: Int, minute: Int, second: Int) -> Date {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         
         // 日付部分を生成
@@ -166,8 +169,7 @@ public extension Date {
     }
     
     static func combine(date: Date, time: Date) -> Date {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
         let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
         let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: time)
 
@@ -183,8 +185,7 @@ public extension Date {
     }
     
     static func combine(date: SimpleDate, time: SimpleTime) -> Date {
-        var calendar = Calendar.current
-        calendar.timeZone = japanTimeZone
+        let calendar = Calendar.japanGregorian
 
         var merged = DateComponents()
         merged.year = date.year
@@ -197,4 +198,3 @@ public extension Date {
         return calendar.date(from: merged) ?? Date()
     }
 }
-

--- a/Shared/Tests/SharedTests.swift
+++ b/Shared/Tests/SharedTests.swift
@@ -6,9 +6,30 @@
 //
 
 import Testing
+import Foundation
 @testable import Shared
 
-@Test func example() {
-    let sum = 1 + 1
-    #expect(sum == 2)
+struct SharedDateTimeTests {
+    @Test
+    func simpleDate_weekdayは日本時間のグレゴリオ暦で計算する() {
+        let date = SimpleDate(year: 2020, month: 10, day: 10)
+
+        #expect(date.weekday == 7)
+    }
+
+    @Test
+    func simpleDate_toDateとfromは日本時間で往復できる() {
+        let original = SimpleDate(year: 2020, month: 10, day: 10)
+        let restored = SimpleDate.from(original.toDate)
+
+        #expect(restored == original)
+    }
+
+    @Test
+    func japanGregorianは東京のグレゴリオ暦を返す() {
+        let calendar = Calendar.japanGregorian
+
+        #expect(calendar.identifier == .gregorian)
+        #expect(calendar.timeZone.identifier == "Asia/Tokyo")
+    }
 }

--- a/iOSApp/Sources/Domain/Entities/Share/Date+Calendar.swift
+++ b/iOSApp/Sources/Domain/Entities/Share/Date+Calendar.swift
@@ -1,7 +1,8 @@
 import Foundation
+import Shared
 
 extension Date {
-    func sameWeekday(in year: Int, calendar: Calendar = .current) -> Date? {
+    func sameWeekday(in year: Int, calendar: Calendar = .japanGregorian) -> Date? {
         let weekday = calendar.component(.weekday, from: self)
         let weekOfMonth = calendar.component(.weekOfMonth, from: self)
         let month = calendar.component(.month, from: self)

--- a/iOSApp/Tests/iOSAppTests.swift
+++ b/iOSApp/Tests/iOSAppTests.swift
@@ -1,11 +1,19 @@
 import Testing
+import Foundation
+import Shared
 @testable import iOSApp
 
+struct iOSAppDateCalendarTests {
+    @Test
+    func sameWeekdayは日本時間のグレゴリオ暦で同じ第何週何曜日を返す() async throws {
+        let source = SimpleDate(year: 2025, month: 10, day: 11).toDate
 
-struct iOSAppTest {
-    @Test func example() async throws {
-        let sum = 1 + 2
-        #expect(sum == 3)
+        let shifted = try #require(source.sameWeekday(in: 2026))
+        let result = Calendar.japanGregorian.dateComponents([.year, .month, .day, .weekday], from: shifted)
+
+        #expect(result.year == 2026)
+        #expect(result.month == 10)
+        #expect(result.day == 10)
+        #expect(result.weekday == 7)
     }
-
 }


### PR DESCRIPTION
## 目的
Issue #271 の曜日表示ずれに対応するため、端末依存のカレンダー解釈を排除します。

## 変更点
- Shared に日本時間のグレゴリオ暦カレンダーを追加
- SimpleDate / SimpleTime / Date の日付計算を共通カレンダーへ統一
- iOSApp の sameWeekday も同じカレンダーを使うよう変更
- 曜日計算と日付往復変換のテストを追加

## 動作確認
- xcodebuild -workspace MaTool.xcworkspace -scheme SharedTests -destination "platform=macOS" -skipMacroValidation test

## 影響範囲・リスク
- iOSApp の build/test/run は、この worktree に iOSApp/Config/Debug.xcconfig が存在しないため未確認です
- xcodebuild 実行時に MaTool.xcworkspace/xcshareddata/ が生成されますが、今回のコミットには含めていません