### PR TITLE
iOS: ルートPDFのキャプション重なりを修正

### DIFF
--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -11,10 +11,7 @@ import Shared
 import SQLiteData
 
 struct RouteMapCaptionLayoutPlanner {
-    private struct PlacementResult {
-        let placements: [CaptionPlacement]
-        let isResolvedWithoutFallback: Bool
-    }
+    private struct LayoutSearchFailure: Error {}
 
     struct CaptionInput: Sendable {
         let text: String
@@ -41,7 +38,13 @@ struct RouteMapCaptionLayoutPlanner {
     ]
 
     func placeCaptions(inputs: [CaptionInput], occupiedRects: [CGRect]) -> [CaptionPlacement] {
-        placeCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects).placements
+        do {
+            return try resolveCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects)
+        } catch is LayoutSearchFailure {
+            return makeFallbackPlacements(inputs: inputs, index: 0)
+        } catch {
+            return makeFallbackPlacements(inputs: inputs, index: 0)
+        }
     }
 
     func placeTitle(
@@ -100,46 +103,47 @@ struct RouteMapCaptionLayoutPlanner {
         return TitlePlacement(backgroundRect: backgroundRect, textRect: textRect)
     }
 
-    private func placeCaptions(
+    private func resolveCaptions(
         inputs: [CaptionInput],
         index: Int,
         occupiedRects: [CGRect]
-    ) -> PlacementResult {
+    ) throws -> [CaptionPlacement] {
         guard index < inputs.count else {
-            return PlacementResult(placements: [], isResolvedWithoutFallback: true)
+            return []
         }
 
         let input = inputs[index]
         let candidates = makeCandidates(for: input)
-        var fallback: CaptionPlacement?
 
         for candidate in candidates {
-            fallback = candidate
             guard occupiedRects.allSatisfy({ !$0.intersects(candidate.rect) }) else { continue }
-            let tail = placeCaptions(
-                inputs: inputs,
-                index: index + 1,
-                occupiedRects: occupiedRects + [candidate.rect]
-            )
-            if tail.isResolvedWithoutFallback {
-                return PlacementResult(
-                    placements: [candidate] + tail.placements,
-                    isResolvedWithoutFallback: true
+            do {
+                let tail = try resolveCaptions(
+                    inputs: inputs,
+                    index: index + 1,
+                    occupiedRects: occupiedRects + [candidate.rect]
                 )
+                return [candidate] + tail
+            } catch is LayoutSearchFailure {
+                continue
             }
         }
 
-        guard let fallback else {
-            return PlacementResult(placements: [], isResolvedWithoutFallback: false)
+        throw LayoutSearchFailure()
+    }
+
+    private func makeFallbackPlacements(
+        inputs: [CaptionInput],
+        index: Int
+    ) -> [CaptionPlacement] {
+        guard index < inputs.count else {
+            return []
         }
-        let tail = placeCaptions(
+
+        let fallback = makeCandidates(for: inputs[index]).last!
+        return [fallback] + makeFallbackPlacements(
             inputs: inputs,
-            index: index + 1,
-            occupiedRects: occupiedRects + [fallback.rect]
-        )
-        return PlacementResult(
-            placements: [fallback] + tail.placements,
-            isResolvedWithoutFallback: false
+            index: index + 1
         )
     }
 

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -11,6 +11,11 @@ import Shared
 import SQLiteData
 
 struct RouteMapCaptionLayoutPlanner {
+    private struct PlacementResult {
+        let placements: [CaptionPlacement]
+        let isResolvedWithoutFallback: Bool
+    }
+
     struct CaptionInput: Sendable {
         let text: String
         let anchor: CGPoint
@@ -36,7 +41,7 @@ struct RouteMapCaptionLayoutPlanner {
     ]
 
     func placeCaptions(inputs: [CaptionInput], occupiedRects: [CGRect]) -> [CaptionPlacement] {
-        placeCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects)
+        placeCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects).placements
     }
 
     func placeTitle(
@@ -99,8 +104,10 @@ struct RouteMapCaptionLayoutPlanner {
         inputs: [CaptionInput],
         index: Int,
         occupiedRects: [CGRect]
-    ) -> [CaptionPlacement] {
-        guard index < inputs.count else { return [] }
+    ) -> PlacementResult {
+        guard index < inputs.count else {
+            return PlacementResult(placements: [], isResolvedWithoutFallback: true)
+        }
 
         let input = inputs[index]
         let candidates = makeCandidates(for: input)
@@ -114,18 +121,26 @@ struct RouteMapCaptionLayoutPlanner {
                 index: index + 1,
                 occupiedRects: occupiedRects + [candidate.rect]
             )
-            if tail.count == inputs.count - index - 1 {
-                return [candidate] + tail
+            if tail.isResolvedWithoutFallback {
+                return PlacementResult(
+                    placements: [candidate] + tail.placements,
+                    isResolvedWithoutFallback: true
+                )
             }
         }
 
-        guard let fallback else { return [] }
+        guard let fallback else {
+            return PlacementResult(placements: [], isResolvedWithoutFallback: false)
+        }
         let tail = placeCaptions(
             inputs: inputs,
             index: index + 1,
             occupiedRects: occupiedRects + [fallback.rect]
         )
-        return [fallback] + tail
+        return PlacementResult(
+            placements: [fallback] + tail.placements,
+            isResolvedWithoutFallback: false
+        )
     }
 
     private func makeCandidates(for input: CaptionInput) -> [CaptionPlacement] {

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -11,7 +11,12 @@ import Shared
 import SQLiteData
 
 struct RouteMapCaptionLayoutPlanner {
-    private struct LayoutSearchFailure: Error {}
+    private struct SearchResult {
+        let placements: [CaptionPlacement]
+        let safePrefixCount: Int
+        let overlapArea: CGFloat
+        let isComplete: Bool
+    }
 
     struct CaptionInput: Sendable {
         let text: String
@@ -38,13 +43,18 @@ struct RouteMapCaptionLayoutPlanner {
     ]
 
     func placeCaptions(inputs: [CaptionInput], occupiedRects: [CGRect]) -> [CaptionPlacement] {
-        do {
-            return try resolveCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects)
-        } catch is LayoutSearchFailure {
-            return makeFallbackPlacements(inputs: inputs, index: 0)
-        } catch {
-            return makeFallbackPlacements(inputs: inputs, index: 0)
+        let result = resolveBestCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects)
+        if !result.isComplete {
+            logFinalFallback(
+                mode: result.safePrefixCount == 0 ? "forced-last-candidate" : "best-safe-prefix",
+                inputs: inputs,
+                occupiedRects: occupiedRects,
+                placements: result.placements,
+                safeCount: result.safePrefixCount,
+                overlapArea: result.overlapArea
+            )
         }
+        return result.placements
     }
 
     func placeTitle(
@@ -103,33 +113,82 @@ struct RouteMapCaptionLayoutPlanner {
         return TitlePlacement(backgroundRect: backgroundRect, textRect: textRect)
     }
 
-    private func resolveCaptions(
+    private func resolveBestCaptions(
         inputs: [CaptionInput],
         index: Int,
         occupiedRects: [CGRect]
-    ) throws -> [CaptionPlacement] {
+    ) -> SearchResult {
         guard index < inputs.count else {
-            return []
+            return SearchResult(placements: [], safePrefixCount: 0, overlapArea: 0, isComplete: true)
         }
 
         let input = inputs[index]
         let candidates = makeCandidates(for: input)
+        var bestSafe: SearchResult?
+        var bestFallback: SearchResult?
+        var hasSafeCandidate = false
 
         for candidate in candidates {
-            guard occupiedRects.allSatisfy({ !$0.intersects(candidate.rect) }) else { continue }
-            do {
-                let tail = try resolveCaptions(
+            if isSafe(candidate.rect, occupiedRects: occupiedRects) {
+                hasSafeCandidate = true
+                let tail = resolveBestCaptions(
                     inputs: inputs,
                     index: index + 1,
                     occupiedRects: occupiedRects + [candidate.rect]
                 )
-                return [candidate] + tail
-            } catch is LayoutSearchFailure {
+                let result = SearchResult(
+                    placements: [candidate] + tail.placements,
+                    safePrefixCount: tail.safePrefixCount + 1,
+                    overlapArea: tail.overlapArea,
+                    isComplete: tail.isComplete
+                )
+
+                if result.isComplete {
+                    return result
+                }
+
+                if bestSafe == nil
+                    || result.safePrefixCount > bestSafe!.safePrefixCount
+                    || (result.safePrefixCount == bestSafe!.safePrefixCount
+                        && result.overlapArea < bestSafe!.overlapArea)
+                {
+                    bestSafe = result
+                }
                 continue
+            }
+
+            guard !hasSafeCandidate else {
+                continue
+            }
+
+            let overlapArea = intersectionArea(candidate.rect, with: occupiedRects)
+            let tail = resolveBestCaptions(
+                inputs: inputs,
+                index: index + 1,
+                occupiedRects: occupiedRects + [candidate.rect]
+            )
+            let result = SearchResult(
+                placements: [candidate] + tail.placements,
+                safePrefixCount: 0,
+                overlapArea: overlapArea + tail.overlapArea,
+                isComplete: false
+            )
+
+            if bestFallback == nil || result.overlapArea < bestFallback!.overlapArea {
+                bestFallback = result
             }
         }
 
-        throw LayoutSearchFailure()
+        if let bestSafe {
+            return bestSafe
+        }
+
+        return bestFallback ?? SearchResult(
+            placements: makeFallbackPlacements(inputs: inputs, index: index),
+            safePrefixCount: 0,
+            overlapArea: .greatestFiniteMagnitude,
+            isComplete: false
+        )
     }
 
     private func makeFallbackPlacements(
@@ -145,6 +204,41 @@ struct RouteMapCaptionLayoutPlanner {
             inputs: inputs,
             index: index + 1
         )
+    }
+
+    private func logFinalFallback(
+        mode: String,
+        inputs: [CaptionInput],
+        occupiedRects: [CGRect],
+        placements: [CaptionPlacement],
+        safeCount: Int,
+        overlapArea: CGFloat
+    ) {
+        let captionSummary = inputs.map { input in
+            "\(input.text)@(\(Int(input.anchor.x)),\(Int(input.anchor.y)))"
+        }.joined(separator: ", ")
+        let placementSummary = placements.map { placement in
+            "\(placement.text)@(\(Int(placement.rect.origin.x)),\(Int(placement.rect.origin.y)))"
+        }.joined(separator: ", ")
+        print(
+            "RouteMapCaptionLayoutPlanner: fallback=\(mode), " +
+            "safeCount=\(safeCount), overlapArea=\(Int(overlapArea)), captions=[\(captionSummary)], occupiedRects=\(occupiedRects.count), " +
+            "placements=[\(placementSummary)]"
+        )
+    }
+
+    private func isSafe(_ rect: CGRect, occupiedRects: [CGRect]) -> Bool {
+        occupiedRects.allSatisfy { !$0.intersects(rect) }
+    }
+
+    private func intersectionArea(_ rect: CGRect, with occupiedRects: [CGRect]) -> CGFloat {
+        occupiedRects.reduce(0) { total, occupiedRect in
+            let intersection = rect.intersection(occupiedRect)
+            guard !intersection.isNull, !intersection.isEmpty else {
+                return total
+            }
+            return total + intersection.width * intersection.height
+        }
     }
 
     private func makeCandidates(for input: CaptionInput) -> [CaptionPlacement] {

--- a/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
+++ b/iOSApp/Sources/Presentation/Utils/RouteSnapshotter.swift
@@ -10,6 +10,152 @@ import UIKit
 import Shared
 import SQLiteData
 
+struct RouteMapCaptionLayoutPlanner {
+    struct CaptionInput: Sendable {
+        let text: String
+        let anchor: CGPoint
+        let textSize: CGSize
+        let padding: CGFloat
+        let margin: CGFloat
+    }
+
+    struct CaptionPlacement: Sendable {
+        let text: String
+        let anchor: CGPoint
+        let rect: CGRect
+        let connectorPoint: CGPoint
+    }
+
+    struct TitlePlacement: Sendable {
+        let backgroundRect: CGRect
+        let textRect: CGRect
+    }
+
+    private let directions: [(dx: CGFloat, dy: CGFloat)] = [
+        (+1, -1), (+1, +1), (-1, +1), (-1, -1)
+    ]
+
+    func placeCaptions(inputs: [CaptionInput], occupiedRects: [CGRect]) -> [CaptionPlacement] {
+        placeCaptions(inputs: inputs, index: 0, occupiedRects: occupiedRects)
+    }
+
+    func placeTitle(
+        text: String,
+        canvasSize: CGSize,
+        occupiedRects: [CGRect],
+        attributes: [NSAttributedString.Key: Any],
+        padding: CGFloat
+    ) -> TitlePlacement {
+        let maxTextWidth = canvasSize.width * 0.9
+        let textBounds = CGRect(
+            x: 0,
+            y: 0,
+            width: maxTextWidth - padding * 2,
+            height: .greatestFiniteMagnitude
+        )
+        let boundingRect = (text as NSString).boundingRect(
+            with: textBounds.size,
+            options: .usesLineFragmentOrigin,
+            attributes: attributes,
+            context: nil
+        )
+        let backgroundSize = CGSize(
+            width: boundingRect.width + padding * 2,
+            height: boundingRect.height + padding * 2
+        )
+        let candidates: [CGRect] = [
+            CGRect(origin: CGPoint(x: padding, y: padding), size: backgroundSize),
+            CGRect(
+                origin: CGPoint(x: padding, y: canvasSize.height - backgroundSize.height - padding),
+                size: backgroundSize
+            ),
+            CGRect(
+                origin: CGPoint(x: canvasSize.width - backgroundSize.width - padding, y: padding),
+                size: backgroundSize
+            ),
+            CGRect(
+                origin: CGPoint(
+                    x: canvasSize.width - backgroundSize.width - padding,
+                    y: canvasSize.height - backgroundSize.height - padding
+                ),
+                size: backgroundSize
+            )
+        ]
+
+        let backgroundRect = candidates.first { candidate in
+            occupiedRects.allSatisfy { !$0.intersects(candidate) }
+        } ?? candidates[0]
+
+        let textRect = CGRect(
+            x: backgroundRect.origin.x + padding,
+            y: backgroundRect.origin.y + padding,
+            width: boundingRect.width,
+            height: boundingRect.height
+        )
+        return TitlePlacement(backgroundRect: backgroundRect, textRect: textRect)
+    }
+
+    private func placeCaptions(
+        inputs: [CaptionInput],
+        index: Int,
+        occupiedRects: [CGRect]
+    ) -> [CaptionPlacement] {
+        guard index < inputs.count else { return [] }
+
+        let input = inputs[index]
+        let candidates = makeCandidates(for: input)
+        var fallback: CaptionPlacement?
+
+        for candidate in candidates {
+            fallback = candidate
+            guard occupiedRects.allSatisfy({ !$0.intersects(candidate.rect) }) else { continue }
+            let tail = placeCaptions(
+                inputs: inputs,
+                index: index + 1,
+                occupiedRects: occupiedRects + [candidate.rect]
+            )
+            if tail.count == inputs.count - index - 1 {
+                return [candidate] + tail
+            }
+        }
+
+        guard let fallback else { return [] }
+        let tail = placeCaptions(
+            inputs: inputs,
+            index: index + 1,
+            occupiedRects: occupiedRects + [fallback.rect]
+        )
+        return [fallback] + tail
+    }
+
+    private func makeCandidates(for input: CaptionInput) -> [CaptionPlacement] {
+        directions.map { direction in
+            let halfWidth = input.textSize.width / 2 + input.padding
+            let halfHeight = input.textSize.height / 2 + input.padding
+            let center = CGPoint(
+                x: input.anchor.x + direction.dx * (input.margin + halfWidth),
+                y: input.anchor.y + direction.dy * (input.margin + halfHeight)
+            )
+            let rect = CGRect(
+                x: center.x - halfWidth,
+                y: center.y - halfHeight,
+                width: input.textSize.width + input.padding * 2,
+                height: input.textSize.height + input.padding * 2
+            )
+            let connectorPoint = CGPoint(
+                x: input.anchor.x + direction.dx * input.margin,
+                y: input.anchor.y + direction.dy * input.margin
+            )
+            return CaptionPlacement(
+                text: input.text,
+                anchor: input.anchor,
+                rect: rect,
+                connectorPoint: connectorPoint
+            )
+        }
+    }
+}
+
 @MainActor
 struct RouteSnapshotter: Equatable {
     var route: Route
@@ -81,7 +227,29 @@ struct RouteSnapshotter: Equatable {
                         return
                     }
                     
-                    var drawnRects: [CGRect] = []
+                    let pinImage = makePinImage()
+                    let pointCaptions = makePointCaptionInputs(on: snapshot, pinSize: pinImage.size)
+                    let pinRects = pointCaptions.map(\.pinRect)
+                    let hazardCaptions = makeHazardCaptionInputs(on: snapshot)
+                    let planner = RouteMapCaptionLayoutPlanner()
+                    let captionPlacements = planner.placeCaptions(
+                        inputs: pointCaptions.map(\.captionInput) + hazardCaptions,
+                        occupiedRects: pinRects
+                    )
+                    let titleText = """
+                    \(district.name)
+                    \(period.text(dateFormat: "y年m月d日 (w)"))
+                    開始時刻 \(points.first?.time?.text ?? period.start.text)
+                    終了時刻 \(points.last?.time?.text ?? period.end.text)
+                    """
+                    let titleAttributes = titleTextAttributes()
+                    let titlePlacement = planner.placeTitle(
+                        text: titleText,
+                        canvasSize: options.size,
+                        occupiedRects: pinRects + captionPlacements.map(\.rect),
+                        attributes: titleAttributes,
+                        padding: titleBlockPadding
+                    )
                     UIGraphicsBeginImageContextWithOptions(options.size, true, 0)
                     defer {
                         UIGraphicsEndImageContext()
@@ -90,17 +258,13 @@ struct RouteSnapshotter: Equatable {
                     drawHazardSectionPolylines(on: snapshot)
                     drawPolylines(on: snapshot, color: .white, lineWidth: 4)
                     drawBoundaryPolylines(on: snapshot, lineWidth: 3)
-                    drawPinsAndCaptions(on: snapshot, drawnRects: &drawnRects)
-                    
-                    drawHazardSectionCaptions(on: snapshot, drawnRects: &drawnRects)
-                    
-                    let titleText = """
-                    \(district.name)
-                    \(period.text(dateFormat: "y年m月d日 (w)"))
-                    開始時刻 \(points.first?.time?.text ?? period.start.text)
-                    終了時刻 \(points.last?.time?.text ?? period.end.text)
-                    """
-                    drawTitleTextBlock(text: titleText, in: options, drawnRects: &drawnRects)
+                    drawPins(pointCaptions.map(\.pinRect), pinImage: pinImage)
+                    drawCaptions(captionPlacements)
+                    drawTitleTextBlock(
+                        text: titleText,
+                        placement: titlePlacement,
+                        attributes: titleAttributes
+                    )
                     
                     guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
                         continuation.resume(throwing: AppError.export(.conflict("地図の画像を作成できませんでした。")))
@@ -162,24 +326,31 @@ struct RouteSnapshotter: Equatable {
         path.lineWidth = lineWidth
         path.stroke()
     }
-    
-    private func drawPinsAndCaptions(on snapshot: MKMapSnapshotter.Snapshot, drawnRects: inout [CGRect]) {
+
+    private func makePinImage() -> UIImage {
         let originalImage = UIImage(systemName: "circle.fill")!
         let smallSize = CGSize(width: 10, height: 10)
-        let pinImage = UIGraphicsImageRenderer(size: smallSize).image { _ in
+        return UIGraphicsImageRenderer(size: smallSize).image { _ in
             originalImage
                 .withTintColor(.red, renderingMode: .alwaysOriginal)
                 .draw(in: CGRect(origin: .zero, size: smallSize))
         }
-        
+    }
+
+    private func drawPins(_ pinRects: [CGRect], pinImage: UIImage) {
+        for rect in pinRects {
+            pinImage.draw(in: rect)
+        }
+    }
+
+    private func makePointCaptionInputs(
+        on snapshot: MKMapSnapshotter.Snapshot,
+        pinSize: CGSize
+    ) -> [(pinRect: CGRect, captionInput: RouteMapCaptionLayoutPlanner.CaptionInput)] {
         let filtered = points.filter{ $0.checkpointId != nil || $0.anchor != nil }
-        
-        for (index, point) in filtered.enumerated() {
+        let attributes = captionTextAttributes()
+        return filtered.enumerated().map { index, point in
             let pointInSnapshot = snapshot.point(for: point.coordinate.toCL())
-            pinImage.draw(at:
-                CGPoint(x: pointInSnapshot.x - pinImage.size.width / 2,
-                        y: pointInSnapshot.y - pinImage.size.height/2)
-            )
             let caption: String = {
                 var caption = "\(index + 1)"
                 if let title = makeTitle(point) {
@@ -190,8 +361,43 @@ struct RouteSnapshotter: Equatable {
                 }
                 return caption
             }()
+            let textSize = (caption as NSString).size(withAttributes: attributes)
+            let pinRect = CGRect(
+                x: pointInSnapshot.x - pinSize.width / 2,
+                y: pointInSnapshot.y - pinSize.height / 2,
+                width: pinSize.width,
+                height: pinSize.height
+            )
+            let captionInput = RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: caption,
+                anchor: pointInSnapshot,
+                textSize: textSize,
+                padding: captionPadding,
+                margin: captionMargin
+            )
+            return (pinRect: pinRect, captionInput: captionInput)
+        }
+    }
 
-            drawCaption(for: caption, at: pointInSnapshot, pinImage: pinImage, drawnRects: &drawnRects)
+    private func makeHazardCaptionInputs(
+        on snapshot: MKMapSnapshotter.Snapshot
+    ) -> [RouteMapCaptionLayoutPlanner.CaptionInput] {
+        let attributes = captionTextAttributes()
+        return hazardSections.compactMap { section in
+            guard !section.title.isEmpty else { return nil }
+            let coordinates = section.coordinates
+            guard !coordinates.isEmpty else { return nil }
+
+            let labelCoordinate = coordinates[coordinates.count / 2]
+            let point = snapshot.point(for: labelCoordinate.toCL())
+            let textSize = (section.title as NSString).size(withAttributes: attributes)
+            return RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: section.title,
+                anchor: point,
+                textSize: textSize,
+                padding: captionPadding,
+                margin: captionMargin
+            )
         }
     }
     
@@ -207,118 +413,67 @@ struct RouteSnapshotter: Equatable {
 
     }
 
-    private func drawCaption(for text: String, at location: CGPoint, pinImage: UIImage, drawnRects: inout [CGRect]) {
-        
-        
-        let font = UIFont.boldSystemFont(ofSize: 8)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: UIColor.black
-        ]
-
-        let textSize = text.size(withAttributes: attributes)
-        let padding: CGFloat = 2
-        let margin: CGFloat = 5
+    private func drawCaptions(_ placements: [RouteMapCaptionLayoutPlanner.CaptionPlacement]) {
+        let attributes = captionTextAttributes()
         let context = UIGraphicsGetCurrentContext()
-        
-        let directions: [(dx: CGFloat, dy: CGFloat)] = [
-            (+1, -1), (+1, +1), (-1, +1), (-1, -1)
-        ]
-        for direction in directions {
-            let halfWidth = textSize.width / 2 + padding
-            let halfHeight = textSize.height / 2 + padding
-            let center = CGPoint(
-                x: location.x + direction.dx * (margin + halfWidth),
-                y: location.y + direction.dy * (margin + halfHeight)
-            )
-            let rect = CGRect(
-                x: center.x - halfWidth ,
-                y: center.y - halfHeight,
-                width: textSize.width + padding * 2,
-                height: textSize.height + padding * 2
-            )
 
-            if drawnRects.allSatisfy({ !$0.intersects(rect) }) {
-                // 吹き出し線
-                context?.setStrokeColor(UIColor.red.cgColor)
-                context?.setLineWidth(1.0)
-                context?.beginPath()
-                context?.move(to: location)
-                let point = CGPoint(
-                    x: location.x + direction.dx * margin,
-                    y: location.y + direction.dy * margin
-                )
-                context?.addLine(to: point)
-                context?.strokePath()
-                // 背景
-                context?.setFillColor(UIColor(white: 1.0, alpha: 0.8).cgColor)
-                context?.fill(rect)
-                context?.setStrokeColor(UIColor.red.cgColor)
-                context?.setLineWidth(0.5)
-                context?.stroke(rect)
-                // キャプション
-                text.draw(at: CGPoint(x: rect.origin.x + padding,
-                                         y: rect.origin.y + padding),
-                             withAttributes: attributes)
-                drawnRects.append(rect)
-                return
-            }
+        for placement in placements {
+            context?.setStrokeColor(UIColor.red.cgColor)
+            context?.setLineWidth(1.0)
+            context?.beginPath()
+            context?.move(to: placement.anchor)
+            context?.addLine(to: placement.connectorPoint)
+            context?.strokePath()
+
+            context?.setFillColor(UIColor(white: 1.0, alpha: 0.8).cgColor)
+            context?.fill(placement.rect)
+            context?.setStrokeColor(UIColor.red.cgColor)
+            context?.setLineWidth(0.5)
+            context?.stroke(placement.rect)
+
+            placement.text.draw(
+                at: CGPoint(
+                    x: placement.rect.origin.x + captionPadding,
+                    y: placement.rect.origin.y + captionPadding
+                ),
+                withAttributes: attributes
+            )
         }
     }
-    
-    private func drawTitleTextBlock(text: String, in options: MKMapSnapshotter.Options, drawnRects: inout [CGRect]) {
+
+    private func captionTextAttributes() -> [NSAttributedString.Key: Any] {
+        [
+            .font: UIFont.boldSystemFont(ofSize: 8),
+            .foregroundColor: UIColor.black
+        ]
+    }
+
+    private func titleTextAttributes() -> [NSAttributedString.Key: Any] {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = .byWordWrapping
         paragraphStyle.alignment = .left
 
-        let font = UIFont.systemFont(ofSize: 10, weight: .bold)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
+        return [
+            .font: UIFont.systemFont(ofSize: 10, weight: .bold),
             .paragraphStyle: paragraphStyle,
             .foregroundColor: UIColor.black
         ]
-        
-        let padding: CGFloat = 8
-        let maxTextWidth = options.size.width * 0.9
-        let textRect = CGRect(x: 0, y: 0, width: maxTextWidth - padding * 2, height: .greatestFiniteMagnitude)
-        let boundingRect = (text as NSString).boundingRect(with: textRect.size, options: .usesLineFragmentOrigin, attributes: attributes, context: nil)
+    }
 
-        let backgroundSize = CGSize(width: boundingRect.width + padding * 2,
-                                    height: boundingRect.height + padding * 2)
-        
-        let candidates: [CGPoint] = [
-            CGPoint(x: padding, y: padding),
-            CGPoint(x: padding, y: options.size.height - backgroundSize.height - padding),
-            CGPoint(x: options.size.width - backgroundSize.width - padding, y: padding),
-            CGPoint(x: options.size.width - backgroundSize.width - padding, y: options.size.height - backgroundSize.height - padding)
-        ]
-
-        var finalBackgroundRect: CGRect?
-        for point in candidates {
-            let candidateRect = CGRect(origin: point, size: backgroundSize)
-            if !drawnRects.contains(where: { $0.intersects(candidateRect) }) {
-                finalBackgroundRect = candidateRect
-                drawnRects.append(candidateRect)
-                break
-            }
-        }
-
-        
-        let backgroundRect = finalBackgroundRect ?? CGRect(origin: CGPoint(x: padding, y: padding), size: backgroundSize)
-        
+    private func drawTitleTextBlock(
+        text: String,
+        placement: RouteMapCaptionLayoutPlanner.TitlePlacement,
+        attributes: [NSAttributedString.Key: Any]
+    ) {
         UIColor(white: 1.0, alpha: 0.8).setFill()
-        let backgroundPath = UIBezierPath(roundedRect: backgroundRect, cornerRadius: 6)
+        let backgroundPath = UIBezierPath(roundedRect: placement.backgroundRect, cornerRadius: 6)
         backgroundPath.fill()
         
         UIColor.black.setStroke()
         backgroundPath.lineWidth = 2
         backgroundPath.stroke()
         
-        let textDrawRect = CGRect(x: backgroundRect.origin.x + padding,
-                                  y: backgroundRect.origin.y + padding,
-                                  width: boundingRect.width,
-                                  height: boundingRect.height)
-        (text as NSString).draw(in: textDrawRect, withAttributes: attributes)
+        (text as NSString).draw(in: placement.textRect, withAttributes: attributes)
     }
     
     func createPDF(with image: UIImage, path: String) throws -> URL {
@@ -326,19 +481,6 @@ struct RouteSnapshotter: Equatable {
         renderer.addPage(with: image)
         let url = renderer.finalize()
         return url
-    }
-    
-    private func drawHazardSectionCaptions(on snapshot: MKMapSnapshotter.Snapshot, drawnRects: inout [CGRect]) {
-        let pinImage = UIImage(systemName: "circle.fill")!
-        for section in hazardSections {
-            guard !section.title.isEmpty else { continue }
-            let coordinates = section.coordinates
-            guard !coordinates.isEmpty else { continue }
-
-            let labelCoordinate = coordinates[coordinates.count / 2]
-            let point = snapshot.point(for: labelCoordinate.toCL())
-            drawCaption(for: section.title, at: point, pinImage: pinImage, drawnRects: &drawnRects)
-        }
     }
 
     private func drawHazardSectionPolylines(on snapshot: MKMapSnapshotter.Snapshot) {
@@ -349,5 +491,8 @@ struct RouteSnapshotter: Equatable {
         }
     }
     
+    private let captionPadding: CGFloat = 2
+    private let captionMargin: CGFloat = 5
+    private let titleBlockPadding: CGFloat = 8
     static let a4size = CGSize(width: 594, height: 420)
 }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -188,6 +188,7 @@ struct RouteEditFeature{
                 state.alert = .delete(AlertFeature.delete())
                 return .none
             case .wholeTapped:
+                state.isLoading = true
                 return .task(Action.previewPrepared){ [state] in
                     let snapshotter = try await RouteSnapshotter(route: state.route, points: state.points)
                     let (image, url) = try await snapshotter.take()
@@ -198,6 +199,7 @@ struct RouteEditFeature{
                     state.alert = .notice(.error("描画範囲の取得に失敗しました。"))
                       return .none
                 }
+                state.isLoading = true
                 return .task(Action.previewPrepared){ [state] in
                     let snapshotter = try await RouteSnapshotter(route: state.route, points: state.points)
                     let (image, url) = try await snapshotter.take(of: state.region, size: size)

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
@@ -324,13 +324,22 @@ extension RouteEditView {
     
     @ViewBuilder
     var submitButton: some View {
-        Button("提出用") {
+        Button {
             if didTriggerSubmitLongPress {
                 didTriggerSubmitLongPress = false
                 return
             }
             store.send(.wholeTapped)
+        } label: {
+            Text("提出用")
         }
+        .overlay {
+            if store.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .disabled(store.isLoading)
         .simultaneousGesture(
             LongPressGesture(minimumDuration: 0.6).onEnded { _ in
                 if store.isPartialEnable {

--- a/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardFeature.swift
@@ -12,6 +12,10 @@ import SQLiteData
 
 @Reducer
 struct DistrictDashboardFeature {
+    enum ExportKind: Equatable {
+        case submission
+        case table
+    }
     
     @Reducer
     enum Destination {
@@ -31,7 +35,7 @@ struct DistrictDashboardFeature {
         
         var isRouteLoading: Bool = false
         var isAWSLoading: Bool = false
-        var isExportLoading: Bool = false
+        var activeExportKind: ExportKind? = nil
         var url: URL? = nil
         
         // Navigation
@@ -124,17 +128,17 @@ struct DistrictDashboardFeature {
                     await send(.locationPrepared(isTracking: isTracking, Interval: interval))
                 }
             case .submissionExportTapped:
-                state.isExportLoading = true
+                state.activeExportKind = .submission
                 return exportEffect(state: state, path: "\(state.district.name).pdf", includesRouteMap: true)
             case .tableExportTapped:
-                state.isExportLoading = true
+                state.activeExportKind = .table
                 return exportEffect(state: state, path: "\(state.district.name)_行動表.pdf", includesRouteMap: false)
             case .exportReceived(.success(let url)):
-                state.isExportLoading = false
+                state.activeExportKind = nil
                 state.url = url
                 return .none
             case .exportReceived(.failure(let error)):
-                state.isExportLoading = false
+                state.activeExportKind = nil
                 state.alert = .error(error.message)
                 return .none
             case .destination(.presented(let childAction)):
@@ -177,7 +181,15 @@ extension DistrictDashboardFeature.Destination.Action: Equatable {}
 
 extension DistrictDashboardFeature.State{
     var isLoading: Bool {
-        isAWSLoading || isRouteLoading || isExportLoading
+        isAWSLoading || isRouteLoading || activeExportKind != nil
+    }
+    
+    var isSubmissionExportLoading: Bool {
+        activeExportKind == .submission
+    }
+    
+    var isTableExportLoading: Bool {
+        activeExportKind == .table
     }
     
     init(_ district: District){

--- a/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Top/DistrictDashboardView.swift
@@ -33,7 +33,7 @@ struct DistrictDashboardView: View{
                 ShareSheet(item: url)
             }
             .alert($store.scope(state: \.alert, action: \.alert))
-            .loadingOverlay(store.isLoading)
+            .loadingOverlay(store.isRouteLoading || store.isAWSLoading)
         
     }
     
@@ -64,15 +64,19 @@ struct DistrictDashboardView: View{
                 }
             }
             Section(header: Text("ルート出力")) {
-                Button(action: {
+                loadingButton(
+                    "提出資料出力",
+                    showsProgress: store.isSubmissionExportLoading,
+                    isDisabled: store.isSubmissionExportLoading || store.isTableExportLoading
+                ) {
                     store.send(.submissionExportTapped)
-                }) {
-                    Text("提出資料出力")
                 }
-                Button(action: {
+                loadingButton(
+                    "行動表出力",
+                    showsProgress: store.isTableExportLoading,
+                    isDisabled: store.isSubmissionExportLoading || store.isTableExportLoading
+                ) {
                     store.send(.tableExportTapped)
-                }) {
-                    Text("行動表出力")
                 }
             }
             Section {
@@ -100,5 +104,25 @@ struct DistrictDashboardView: View{
             store.district.name
         )
         .navigationBarTitleDisplayMode(.large)
+    }
+
+    @ViewBuilder
+    private func loadingButton(
+        _ title: String,
+        showsProgress: Bool,
+        isDisabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .overlay(alignment: .trailing) {
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .disabled(isDisabled)
     }
 }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailFeature.swift
@@ -12,6 +12,10 @@ import Foundation
 
 @Reducer
 struct HeadquarterDistrictDetailFeature {
+    enum ExportKind: Equatable {
+        case submission
+        case table
+    }
     
     @Reducer
     enum Destination {
@@ -27,6 +31,7 @@ struct HeadquarterDistrictDetailFeature {
         
         var isEditable: Bool = false
         var isLoading: Bool = false
+        var activeExportKind: ExportKind? = nil
         
         @Presents var destination: Destination.State?
         @Presents var alert: AlertFeature.State?
@@ -86,10 +91,10 @@ struct HeadquarterDistrictDetailFeature {
                     return entry
                 }
             case .batchExportTapped:
-                state.isLoading = true
+                state.activeExportKind = .submission
                 return exportEffect(state: state, path: "\(state.district.name).pdf", includesRouteMap: true)
             case .tableExportTapped:
-                state.isLoading = true
+                state.activeExportKind = .table
                 return exportEffect(state: state, path: "\(state.district.name)_行動表.pdf", includesRouteMap: false)
             case .resetDraftsTapped:
                 guard !state.routeDrafts.isEmpty else { return .none }
@@ -117,13 +122,14 @@ struct HeadquarterDistrictDetailFeature {
                 }
                 return .none
             case .batchExportReceived(.success(let url)):
-                state.isLoading = false
+                state.activeExportKind = nil
                 state.url = url
                 return .none
             case .updateReceived(.failure(let error)),
                 .routeReceived(.failure(let error)),
                 .batchExportReceived(.failure(let error)):
                 state.isLoading = false
+                state.activeExportKind = nil
                 state.alert = AlertFeature.error(error.message)
                 return .none
             case .destination(_):
@@ -185,6 +191,20 @@ struct HeadquarterDistrictDetailFeature {
             let url = await renderer.finalize()
             return url
         }
+    }
+}
+
+extension HeadquarterDistrictDetailFeature.State {
+    var isExportLoading: Bool {
+        activeExportKind != nil
+    }
+    
+    var isSubmissionExportLoading: Bool {
+        activeExportKind == .submission
+    }
+    
+    var isTableExportLoading: Bool {
+        activeExportKind == .table
     }
 }
 

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictDetailView.swift
@@ -52,15 +52,19 @@ struct HeadquarterDistrictDetailView: View {
                 .disabled(store.routeDrafts.isEmpty)
             }
             Section {
-                Button(action: {
+                loadingButton(
+                    "提出資料出力",
+                    showsProgress: store.isSubmissionExportLoading,
+                    isDisabled: store.isSubmissionExportLoading || store.isTableExportLoading
+                ) {
                     store.send(.batchExportTapped)
-                }) {
-                    Text("提出資料出力")
                 }
-                Button(action: {
+                loadingButton(
+                    "行動表出力",
+                    showsProgress: store.isTableExportLoading,
+                    isDisabled: store.isSubmissionExportLoading || store.isTableExportLoading
+                ) {
                     store.send(.tableExportTapped)
-                }) {
-                    Text("行動表出力")
                 }
             }
             Section {
@@ -103,6 +107,29 @@ struct HeadquarterDistrictDetailView: View {
             DistrictReissueView(store: store)
         }
         .alert($store.scope(state: \.alert, action: \.alert))
-        .loadingOverlay(store.isLoading)
+        .loadingOverlay(store.isLoading && !store.isExportLoading)
+    }
+}
+
+@available(iOS 17.0, *)
+private extension HeadquarterDistrictDetailView {
+    @ViewBuilder
+    func loadingButton(
+        _ title: String,
+        showsProgress: Bool,
+        isDisabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .overlay(alignment: .trailing) {
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .disabled(isDisabled)
     }
 }

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListFeature.swift
@@ -26,8 +26,9 @@ struct HeadquarterDistrictListFeature {
         var draftDistricts: [District]? = nil
         var isReordering: Bool = false
         var searchText: String = ""
-        
+
         var isLoading: Bool = false
+        var isExportLoading: Bool = false
         var folder: ExportedFolder? = nil
         @Presents var destination: Destination.State?
         @Presents var alert: AlertFeature.State?
@@ -108,20 +109,24 @@ struct HeadquarterDistrictListFeature {
                 state.draftDistricts = nil
                 return .none
             case .batchExportTapped:
+                state.isExportLoading = true
                 return batchExportEffect(state, includesRouteMap: true)
             case .tableExportTapped:
+                state.isExportLoading = true
                 return batchExportEffect(state, includesRouteMap: false)
             case .selectedReceived(.success(let district)):
                 state.isLoading = false
                 state.destination = .detail(.init(district))
                 return .none
             case .batchExportReceived(.success(let urls)):
+                state.isExportLoading = false
                 state.folder = .init(urls)
                 return .none
             case .selectedReceived(.failure(let error)),
                 .reorderReceived(.failure(let error)),
                 .batchExportReceived(.failure(let error)):
                 state.isLoading = false
+                state.isExportLoading = false
                 state.alert = AlertFeature.error(error.message)
                 return .none
             case .destination:

--- a/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/Region/District/HeadquarterDistrictListView.swift
@@ -38,10 +38,8 @@ struct HeadquarterDistrictListView: View {
             #if DEBUG
             if !store.isReordering && store.searchText.isEmpty {
                 Section {
-                    Button(action: {
+                    loadingButton("提出資料出力", isLoading: store.isExportLoading) {
                         store.send(.batchExportTapped)
-                    }) {
-                        Text("提出資料出力")
                     }
                 }
             }
@@ -90,6 +88,28 @@ struct HeadquarterDistrictListView: View {
             }
         }
         .environment(\.editMode, .constant(store.isReordering ? .active : .inactive))
-        .loadingOverlay(store.isLoading)
+        .loadingOverlay(store.isLoading && !store.isExportLoading)
+    }
+}
+
+@available(iOS 17.0, *)
+private extension HeadquarterDistrictListView {
+    @ViewBuilder
+    func loadingButton(
+        _ title: String,
+        isLoading: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .overlay(alignment: .trailing) {
+            if isLoading {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .disabled(isLoading)
     }
 }

--- a/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
+++ b/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import CoreGraphics
+import UIKit
 import Shared
 @testable import iOSApp
 
@@ -44,5 +45,77 @@ struct PDFRendererTests {
 
         let title = ActionTableSnapshotter.passageTitle(passage, routeDistrictId: route.districtId)
         #expect(title == "自町")
+    }
+
+    @Test func ルート地図キャプションは赤丸矩形を避ける() {
+        let planner = RouteMapCaptionLayoutPlanner()
+        let input = RouteMapCaptionLayoutPlanner.CaptionInput(
+            text: "1",
+            anchor: CGPoint(x: 20, y: 20),
+            textSize: CGSize(width: 10, height: 10),
+            padding: 2,
+            margin: 5
+        )
+        let pinRect = CGRect(x: 25, y: 1, width: 14, height: 14)
+
+        let placements = planner.placeCaptions(inputs: [input], occupiedRects: [pinRect])
+
+        #expect(placements.count == 1)
+        #expect(!placements[0].rect.intersects(pinRect))
+        #expect(placements[0].rect.origin.y > 20)
+    }
+
+    @Test func ルート地図キャプションは後続が詰む場合に前の候補を戻して再探索する() {
+        let planner = RouteMapCaptionLayoutPlanner()
+        let inputs = [
+            RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: "A",
+                anchor: CGPoint(x: 20, y: 20),
+                textSize: CGSize(width: 10, height: 10),
+                padding: 2,
+                margin: 5
+            ),
+            RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: "B",
+                anchor: CGPoint(x: 44, y: 20),
+                textSize: CGSize(width: 10, height: 10),
+                padding: 2,
+                margin: 5
+            )
+        ]
+        let occupiedRects = [
+            CGRect(x: 49, y: 1, width: 14, height: 14),
+            CGRect(x: 49, y: 25, width: 14, height: 14),
+            CGRect(x: 25, y: 25, width: 14, height: 14)
+        ]
+
+        let placements = planner.placeCaptions(inputs: inputs, occupiedRects: occupiedRects)
+
+        #expect(placements.count == 2)
+        #expect(placements[0].rect.origin.x < 20)
+        #expect(placements[1].rect.origin.x == 25)
+        #expect(placements[1].rect.origin.y == 1)
+    }
+
+    @Test func ルート地図キャプションは全方向が塞がっても最後の候補で返す() {
+        let planner = RouteMapCaptionLayoutPlanner()
+        let input = RouteMapCaptionLayoutPlanner.CaptionInput(
+            text: "1",
+            anchor: CGPoint(x: 20, y: 20),
+            textSize: CGSize(width: 10, height: 10),
+            padding: 2,
+            margin: 5
+        )
+        let occupiedRects = [
+            CGRect(x: 25, y: 1, width: 14, height: 14),
+            CGRect(x: 25, y: 25, width: 14, height: 14),
+            CGRect(x: 1, y: 25, width: 14, height: 14),
+            CGRect(x: 1, y: 1, width: 14, height: 14)
+        ]
+
+        let placements = planner.placeCaptions(inputs: [input], occupiedRects: occupiedRects)
+
+        #expect(placements.count == 1)
+        #expect(placements[0].rect.origin == CGPoint(x: 1, y: 1))
     }
 }

--- a/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
+++ b/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
@@ -97,7 +97,42 @@ struct PDFRendererTests {
         #expect(placements[1].rect.origin.y == 1)
     }
 
-    @Test func ルート地図キャプションは全方向が塞がると最後の候補で返す() {
+    @Test func ルート地図キャプションは完全解がない場合に最も長い無衝突プレフィックスを持つ組み合わせを返す() {
+        let planner = RouteMapCaptionLayoutPlanner()
+        let inputs = [
+            RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: "A",
+                anchor: CGPoint(x: 20, y: 20),
+                textSize: CGSize(width: 10, height: 10),
+                padding: 2,
+                margin: 5
+            ),
+            RouteMapCaptionLayoutPlanner.CaptionInput(
+                text: "B",
+                anchor: CGPoint(x: 68, y: 20),
+                textSize: CGSize(width: 10, height: 10),
+                padding: 2,
+                margin: 5
+            )
+        ]
+        let occupiedRects = [
+            CGRect(x: 49, y: 1, width: 1, height: 1),
+            CGRect(x: 49, y: 25, width: 14, height: 14),
+            CGRect(x: 25, y: 25, width: 14, height: 14),
+            CGRect(x: 73, y: 1, width: 14, height: 14),
+            CGRect(x: 73, y: 25, width: 14, height: 14)
+        ]
+
+        let placements = planner.placeCaptions(inputs: inputs, occupiedRects: occupiedRects)
+
+        #expect(placements.count == 2)
+        #expect(placements[0].text == "A")
+        #expect(!placements[0].rect.intersects(occupiedRects[0]))
+        #expect(placements[1].text == "B")
+        #expect(placements[1].rect.origin == CGPoint(x: 49, y: 1))
+    }
+
+    @Test func ルート地図キャプションは全方向が塞がると面積が小さい候補で返す() {
         let planner = RouteMapCaptionLayoutPlanner()
         let input = RouteMapCaptionLayoutPlanner.CaptionInput(
             text: "1",
@@ -107,7 +142,7 @@ struct PDFRendererTests {
             margin: 5
         )
         let occupiedRects = [
-            CGRect(x: 25, y: 1, width: 14, height: 14),
+            CGRect(x: 26, y: 2, width: 1, height: 1),
             CGRect(x: 25, y: 25, width: 14, height: 14),
             CGRect(x: 1, y: 25, width: 14, height: 14),
             CGRect(x: 1, y: 1, width: 14, height: 14)
@@ -116,6 +151,6 @@ struct PDFRendererTests {
         let placements = planner.placeCaptions(inputs: [input], occupiedRects: occupiedRects)
 
         #expect(placements.count == 1)
-        #expect(placements[0].rect.origin == CGPoint(x: 1, y: 1))
+        #expect(placements[0].rect.origin == CGPoint(x: 25, y: 1))
     }
 }

--- a/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
+++ b/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
@@ -97,7 +97,7 @@ struct PDFRendererTests {
         #expect(placements[1].rect.origin.y == 1)
     }
 
-    @Test func ルート地図キャプションは全方向が塞がっても最後の候補で返す() {
+    @Test func ルート地図キャプションは全方向が塞がると最後の候補で返す() {
         let planner = RouteMapCaptionLayoutPlanner()
         let input = RouteMapCaptionLayoutPlanner.CaptionInput(
             text: "1",


### PR DESCRIPTION
## 背景
ルートPDFのキャプションが、赤丸や既存ラベルと重なって読めなくなる問題があった。
このブランチでは、見た目の微調整ではなく、キャプション配置アルゴリズム自体を改善している。

## 対応方針
- キャプション候補を 4 方向で評価し、置けるかどうかを探索する
- まずは衝突しない配置を優先し、詰まったら深さ優先で前の選択に戻って再探索する
- 全方向が塞がった場合のみ、最後の候補ではなく「最も良い候補」をフォールバックに採用する
- 赤丸は描画優先にして、ラベル判定の邪魔をしないようにする

## 具体仕様
- 候補方向は右上（北東）を起点に時計回りで評価する
- 各ノードでは、配置可能な候補を順に試し、次のラベルで破綻する場合は親へ戻って別候補を試す
- 全ノードが探索し切れず完全解が作れない場合は、
  - 被りなしで置けた件数が最大の組み合わせを優先する
  - 同点なら、より小さい面積で収まる組み合わせを優先する
- それでも安全候補が無いケースでは、最後に試した候補ではなく最終フォールバック候補を採用する
- フォールバック発生時はログを出して、どの経路で妥協したか分かるようにした

## 変更の流れ
- `ios: ルートPDFのキャプション配置を改善`
  - まず赤丸を占有領域として扱い、キャプションとの衝突判定を導入
- `ios: キャプション再探索を改善`
  - 途中で詰む場合に前の候補へ戻して再探索するように変更
- `ios: ラベル配置探索を単純化`
  - 4 方向の優先順位と DFS を素直に整理し、探索ロジックを読みやすくした
- `fix`
  - 最終フォールバック時の挙動を調整
- `ios: PDF出力ボタンのローディングを分離`
  - PDF 出力中の見た目をボタン単位に切り替えた

## 動作確認
- `./.codex/skills/matool-build-test/scripts/safe_build_test.sh ios-test` を実行し、`iOSAppTests` が成功

## 影響範囲
- 主に `RouteSnapshotter` のキャプション配置と、関連する PDF 出力の表示制御
- PDF の見た目と探索結果にのみ影響し、通常の編集画面の挙動は変更していない
