### PR TITLE
ios: 町域オーバーレイを追加

### DIFF
--- a/iOSApp/Sources/Presentation/Parts/Map/DistrictAreaOverlay.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/DistrictAreaOverlay.swift
@@ -1,0 +1,286 @@
+//
+//  DistrictAreaOverlay.swift
+//  MaTool
+//
+//  Created by OpenAI Codex on 2026/06/25.
+//
+
+import Foundation
+import Shared
+
+struct DistrictAreaOverlay: Equatable, Hashable, Identifiable {
+    let districtId: District.ID
+    let districtName: String
+    let area: [Coordinate]
+    let center: Coordinate
+    let colorIndex: Int
+
+    var id: District.ID { districtId }
+}
+
+private let districtAreaPaletteSize = 4
+private let districtAreaNearDistanceDegrees = 0.00015
+private let districtAreaGeometryEpsilon = 1e-9
+
+func assignDistrictAreaOverlays(
+    districts: [District],
+    nearDistanceDegrees: Double = districtAreaNearDistanceDegrees
+) -> [DistrictAreaOverlay] {
+    let polygons = districts
+        .filter { $0.area.count >= 3 }
+        .sorted()
+        .map {
+            DistrictAreaPolygonSource(
+                districtId: $0.id,
+                districtName: $0.name,
+                area: $0.area,
+                center: $0.area.polygonCenter,
+                boundingBox: .from($0.area)
+            )
+        }
+
+    guard !polygons.isEmpty else { return [] }
+
+    let adjacency = buildAdjacency(polygons: polygons, nearDistanceDegrees: nearDistanceDegrees)
+    let colorIndexByDistrictId = assignColorIndices(
+        polygons: polygons,
+        adjacency: adjacency,
+        paletteSize: districtAreaPaletteSize
+    )
+
+    return polygons.map {
+        DistrictAreaOverlay(
+            districtId: $0.districtId,
+            districtName: $0.districtName,
+            area: $0.area,
+            center: $0.center,
+            colorIndex: colorIndexByDistrictId[$0.districtId, default: 0]
+        )
+    }
+}
+
+private func assignColorIndices(
+    polygons: [DistrictAreaPolygonSource],
+    adjacency: [District.ID: Set<District.ID>],
+    paletteSize: Int
+) -> [District.ID: Int] {
+    let orderedPolygons = polygons.sorted {
+        let lhsDegree = adjacency[$0.districtId, default: []].count
+        let rhsDegree = adjacency[$1.districtId, default: []].count
+        if lhsDegree != rhsDegree { return lhsDegree > rhsDegree }
+        if $0.area.count != $1.area.count { return $0.area.count > $1.area.count }
+        return $0.districtId < $1.districtId
+    }
+
+    var assigned: [District.ID: Int] = [:]
+
+    for polygon in orderedPolygons {
+        let neighborColors = Set(adjacency[polygon.districtId, default: []].compactMap { assigned[$0] })
+        if let firstAvailable = (0..<paletteSize).first(where: { !neighborColors.contains($0) }) {
+            assigned[polygon.districtId] = firstAvailable
+            continue
+        }
+
+        let fallback = (0..<paletteSize).min { lhs, rhs in
+            let lhsCount = adjacency[polygon.districtId, default: []].filter { assigned[$0] == lhs }.count
+            let rhsCount = adjacency[polygon.districtId, default: []].filter { assigned[$0] == rhs }.count
+            return lhsCount < rhsCount
+        } ?? 0
+        assigned[polygon.districtId] = fallback
+    }
+
+    return assigned
+}
+
+private func buildAdjacency(
+    polygons: [DistrictAreaPolygonSource],
+    nearDistanceDegrees: Double
+) -> [District.ID: Set<District.ID>] {
+    var adjacency = Dictionary(uniqueKeysWithValues: polygons.map { ($0.districtId, Set<District.ID>()) })
+
+    for (index, lhs) in polygons.enumerated() {
+        let expandedLhs = lhs.boundingBox.expand(nearDistanceDegrees)
+        for rhs in polygons.dropFirst(index + 1) {
+            if !expandedLhs.intersects(rhs.boundingBox.expand(nearDistanceDegrees)) {
+                continue
+            }
+            if polygonDistance(lhs.area, rhs.area) <= nearDistanceDegrees {
+                adjacency[lhs.districtId, default: []].insert(rhs.districtId)
+                adjacency[rhs.districtId, default: []].insert(lhs.districtId)
+            }
+        }
+    }
+
+    return adjacency
+}
+
+private func polygonDistance(_ lhs: [Coordinate], _ rhs: [Coordinate]) -> Double {
+    let lhsEdges = polygonEdges(lhs)
+    let rhsEdges = polygonEdges(rhs)
+    var minDistance = Double.infinity
+
+    for lhsEdge in lhsEdges {
+        for rhsEdge in rhsEdges {
+            if segmentsIntersect(lhsEdge, rhsEdge) {
+                return 0
+            }
+            minDistance = min(
+                minDistance,
+                min(
+                    pointToSegmentDistance(lhsEdge.start, rhsEdge),
+                    pointToSegmentDistance(lhsEdge.end, rhsEdge),
+                    pointToSegmentDistance(rhsEdge.start, lhsEdge),
+                    pointToSegmentDistance(rhsEdge.end, lhsEdge)
+                )
+            )
+        }
+    }
+
+    return minDistance
+}
+
+private func polygonEdges(_ polygon: [Coordinate]) -> [Segment] {
+    guard polygon.count >= 2 else { return [] }
+    return polygon.indices.map { index in
+        let next = (index + 1) % polygon.count
+        return Segment(start: polygon[index], end: polygon[next])
+    }
+}
+
+private func pointToSegmentDistance(_ point: Coordinate, _ segment: Segment) -> Double {
+    let dx = segment.end.longitude - segment.start.longitude
+    let dy = segment.end.latitude - segment.start.latitude
+
+    if abs(dx) <= districtAreaGeometryEpsilon, abs(dy) <= districtAreaGeometryEpsilon {
+        return coordinateDistance(point, segment.start)
+    }
+
+    let t = (((point.longitude - segment.start.longitude) * dx) + ((point.latitude - segment.start.latitude) * dy))
+        / ((dx * dx) + (dy * dy))
+    let clamped = min(max(t, 0), 1)
+    let projected = Coordinate(
+        latitude: segment.start.latitude + dy * clamped,
+        longitude: segment.start.longitude + dx * clamped
+    )
+    return coordinateDistance(point, projected)
+}
+
+private func coordinateDistance(_ lhs: Coordinate, _ rhs: Coordinate) -> Double {
+    hypot(lhs.latitude - rhs.latitude, lhs.longitude - rhs.longitude)
+}
+
+private func segmentsIntersect(_ lhs: Segment, _ rhs: Segment) -> Bool {
+    let o1 = orientation(lhs.start, lhs.end, rhs.start)
+    let o2 = orientation(lhs.start, lhs.end, rhs.end)
+    let o3 = orientation(rhs.start, rhs.end, lhs.start)
+    let o4 = orientation(rhs.start, rhs.end, lhs.end)
+
+    if o1 * o2 < 0, o3 * o4 < 0 { return true }
+    if abs(o1) <= districtAreaGeometryEpsilon, pointOnSegment(rhs.start, lhs) { return true }
+    if abs(o2) <= districtAreaGeometryEpsilon, pointOnSegment(rhs.end, lhs) { return true }
+    if abs(o3) <= districtAreaGeometryEpsilon, pointOnSegment(lhs.start, rhs) { return true }
+    if abs(o4) <= districtAreaGeometryEpsilon, pointOnSegment(lhs.end, rhs) { return true }
+    return false
+}
+
+private func orientation(_ a: Coordinate, _ b: Coordinate, _ c: Coordinate) -> Double {
+    ((b.longitude - a.longitude) * (c.latitude - a.latitude))
+        - ((b.latitude - a.latitude) * (c.longitude - a.longitude))
+}
+
+private func pointOnSegment(_ point: Coordinate, _ segment: Segment) -> Bool {
+    let minLat = min(segment.start.latitude, segment.end.latitude) - districtAreaGeometryEpsilon
+    let maxLat = max(segment.start.latitude, segment.end.latitude) + districtAreaGeometryEpsilon
+    let minLng = min(segment.start.longitude, segment.end.longitude) - districtAreaGeometryEpsilon
+    let maxLng = max(segment.start.longitude, segment.end.longitude) + districtAreaGeometryEpsilon
+
+    return abs(orientation(segment.start, segment.end, point)) <= districtAreaGeometryEpsilon
+        && (minLat...maxLat).contains(point.latitude)
+        && (minLng...maxLng).contains(point.longitude)
+}
+
+private struct DistrictAreaPolygonSource {
+    let districtId: District.ID
+    let districtName: String
+    let area: [Coordinate]
+    let center: Coordinate
+    let boundingBox: BoundingBox
+}
+
+private struct Segment {
+    let start: Coordinate
+    let end: Coordinate
+}
+
+private struct BoundingBox {
+    let minLatitude: Double
+    let maxLatitude: Double
+    let minLongitude: Double
+    let maxLongitude: Double
+
+    func expand(_ delta: Double) -> Self {
+        .init(
+            minLatitude: minLatitude - delta,
+            maxLatitude: maxLatitude + delta,
+            minLongitude: minLongitude - delta,
+            maxLongitude: maxLongitude + delta
+        )
+    }
+
+    func intersects(_ other: Self) -> Bool {
+        !(maxLatitude < other.minLatitude
+            || other.maxLatitude < minLatitude
+            || maxLongitude < other.minLongitude
+            || other.maxLongitude < minLongitude)
+    }
+
+    static func from(_ points: [Coordinate]) -> Self {
+        .init(
+            minLatitude: points.map(\.latitude).min() ?? 0,
+            maxLatitude: points.map(\.latitude).max() ?? 0,
+            minLongitude: points.map(\.longitude).min() ?? 0,
+            maxLongitude: points.map(\.longitude).max() ?? 0
+        )
+    }
+}
+
+private extension Array where Element == Coordinate {
+    var polygonCenter: Coordinate {
+        guard !isEmpty else {
+            return Coordinate(latitude: 0, longitude: 0)
+        }
+        guard count >= 3 else {
+            return Coordinate(
+                latitude: map(\.latitude).reduce(0, +) / Double(count),
+                longitude: map(\.longitude).reduce(0, +) / Double(count)
+            )
+        }
+
+        var twiceArea = 0.0
+        var centroidLatitude = 0.0
+        var centroidLongitude = 0.0
+
+        for index in indices {
+            let next = (index + 1) % count
+            let current = self[index]
+            let following = self[next]
+            let cross = (current.longitude * following.latitude) - (following.longitude * current.latitude)
+            twiceArea += cross
+            centroidLatitude += (current.latitude + following.latitude) * cross
+            centroidLongitude += (current.longitude + following.longitude) * cross
+        }
+
+        if abs(twiceArea) <= districtAreaGeometryEpsilon {
+            return Coordinate(
+                latitude: map(\.latitude).reduce(0, +) / Double(count),
+                longitude: map(\.longitude).reduce(0, +) / Double(count)
+            )
+        }
+
+        let factor = 1 / (3 * twiceArea)
+        return Coordinate(
+            latitude: centroidLatitude * factor,
+            longitude: centroidLongitude * factor
+        )
+    }
+}

--- a/iOSApp/Sources/Presentation/Parts/Map/DistrictAreaOverlay.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/DistrictAreaOverlay.swift
@@ -270,7 +270,7 @@ private extension Array where Element == Coordinate {
             centroidLongitude += (current.longitude + following.longitude) * cross
         }
 
-        if abs(twiceArea) <= districtAreaGeometryEpsilon {
+        if Swift.abs(twiceArea) <= districtAreaGeometryEpsilon {
             return Coordinate(
                 latitude: map(\.latitude).reduce(0, +) / Double(count),
                 longitude: map(\.longitude).reduce(0, +) / Double(count)

--- a/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
@@ -322,7 +322,7 @@ final class DistrictAreaLabelAnnotationView: MKAnnotationView {
         return UIGraphicsImageRenderer(size: size).image { _ in
             let rect = CGRect(origin: .zero, size: size)
             let path = UIBezierPath(roundedRect: rect, cornerRadius: size.height / 2)
-            color.withAlphaComponent(0.92).setFill()
+            color.withAlphaComponent(0.80).setFill()
             path.fill()
 
             UIColor.white.setStroke()

--- a/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
@@ -254,17 +254,21 @@ let districtAreaPalette: [UIColor] = [
     UIColor(red: 0.15, green: 0.67, blue: 0.62, alpha: 1),
 ]
 
-final class DistrictPolygonOverlay: MKPolygon {
+final class DistrictPolygonOverlay: NSObject, MKOverlay {
     let districtAreaOverlay: DistrictAreaOverlay
+    let coordinate: CLLocationCoordinate2D
+    let boundingMapRect: MKMapRect
 
     init(_ districtAreaOverlay: DistrictAreaOverlay) {
         self.districtAreaOverlay = districtAreaOverlay
-        let coordinates = districtAreaOverlay.area.map { $0.toCL() }
-        super.init(coordinates: coordinates, count: coordinates.count)
+        self.coordinate = districtAreaOverlay.center.toCL()
+        self.boundingMapRect = MKMapRect.from(coordinates: districtAreaOverlay.area)
     }
 
     func renderer() -> MKOverlayRenderer {
-        let renderer = MKPolygonRenderer(overlay: self)
+        let coordinates = districtAreaOverlay.area.map { $0.toCL() }
+        let polygon = MKPolygon(coordinates: coordinates, count: coordinates.count)
+        let renderer = MKPolygonRenderer(polygon: polygon)
         let color = districtAreaPalette[districtAreaOverlay.colorIndex % districtAreaPalette.count]
         renderer.fillColor = color.withAlphaComponent(0.3)
         renderer.strokeColor = color.withAlphaComponent(0.9)
@@ -379,6 +383,20 @@ fileprivate extension UIImage {
             cgContext.scaleBy(x: scale, y: scale)
             self.draw(at: .zero)
         }
+    }
+}
+
+private extension MKMapRect {
+    static func from(coordinates: [Coordinate]) -> MKMapRect {
+        guard let first = coordinates.first?.toCL() else { return .null }
+
+        let firstPoint = MKMapPoint(first)
+        var rect = MKMapRect(x: firstPoint.x, y: firstPoint.y, width: 0, height: 0)
+        for coordinate in coordinates.dropFirst() {
+            let point = MKMapPoint(coordinate.toCL())
+            rect = rect.union(MKMapRect(x: point.x, y: point.y, width: 0, height: 0))
+        }
+        return rect
     }
 }
 

--- a/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/MapFragments.swift
@@ -247,6 +247,110 @@ final class PathPolyline: MKPolyline {
     }
 }
 
+let districtAreaPalette: [UIColor] = [
+    UIColor(red: 0.44, green: 0.35, blue: 0.85, alpha: 1),
+    UIColor(red: 0.83, green: 0.36, blue: 0.73, alpha: 1),
+    UIColor(red: 0.22, green: 0.57, blue: 0.86, alpha: 1),
+    UIColor(red: 0.15, green: 0.67, blue: 0.62, alpha: 1),
+]
+
+final class DistrictPolygonOverlay: MKPolygon {
+    let districtAreaOverlay: DistrictAreaOverlay
+
+    init(_ districtAreaOverlay: DistrictAreaOverlay) {
+        self.districtAreaOverlay = districtAreaOverlay
+        let coordinates = districtAreaOverlay.area.map { $0.toCL() }
+        super.init(coordinates: coordinates, count: coordinates.count)
+    }
+
+    func renderer() -> MKOverlayRenderer {
+        let renderer = MKPolygonRenderer(overlay: self)
+        let color = districtAreaPalette[districtAreaOverlay.colorIndex % districtAreaPalette.count]
+        renderer.fillColor = color.withAlphaComponent(0.3)
+        renderer.strokeColor = color.withAlphaComponent(0.9)
+        renderer.lineWidth = 1.5
+        return renderer
+    }
+}
+
+final class DistrictAreaLabelAnnotation: MKPointAnnotation {
+    let districtAreaOverlay: DistrictAreaOverlay
+
+    init(_ districtAreaOverlay: DistrictAreaOverlay) {
+        self.districtAreaOverlay = districtAreaOverlay
+        super.init()
+        coordinate = districtAreaOverlay.center.toCL()
+        title = districtAreaOverlay.districtName
+    }
+}
+
+final class DistrictAreaLabelAnnotationView: MKAnnotationView {
+    static let identifier = "DistrictAreaLabelAnnotationView"
+
+    override var annotation: MKAnnotation? {
+        didSet {
+            configure()
+        }
+    }
+
+    private func configure() {
+        guard let annotation = annotation as? DistrictAreaLabelAnnotation else { return }
+
+        let color = districtAreaPalette[annotation.districtAreaOverlay.colorIndex % districtAreaPalette.count]
+        image = renderedImage(title: annotation.districtAreaOverlay.districtName, color: color)
+        centerOffset = CGPoint(x: 0, y: -6)
+        displayPriority = .required
+        zPriority = .defaultSelected
+        canShowCallout = false
+    }
+
+    private func renderedImage(title: String, color: UIColor) -> UIImage? {
+        let font = UIFont.preferredFont(forTextStyle: .caption1).bold()
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
+        let textSize = (title as NSString).size(withAttributes: attributes)
+        let horizontalPadding: CGFloat = 14
+        let verticalPadding: CGFloat = 8
+        let size = CGSize(
+            width: textSize.width + horizontalPadding * 2,
+            height: textSize.height + verticalPadding * 2
+        )
+
+        return UIGraphicsImageRenderer(size: size).image { _ in
+            let rect = CGRect(origin: .zero, size: size)
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: size.height / 2)
+            color.withAlphaComponent(0.92).setFill()
+            path.fill()
+
+            UIColor.white.setStroke()
+            path.lineWidth = 1
+            path.stroke()
+
+            let textRect = CGRect(
+                x: (size.width - textSize.width) / 2,
+                y: (size.height - textSize.height) / 2,
+                width: textSize.width,
+                height: textSize.height
+            )
+            (title as NSString).draw(
+                in: textRect,
+                withAttributes: [
+                    .font: font,
+                    .foregroundColor: UIColor.white,
+                ]
+            )
+        }
+    }
+}
+
+extension DistrictAreaLabelAnnotationView {
+    static func view(for mapView: MKMapView, annotation: DistrictAreaLabelAnnotation) -> MKAnnotationView {
+        let annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? DistrictAreaLabelAnnotationView
+            ?? DistrictAreaLabelAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+        annotationView.annotation = annotation
+        return annotationView
+    }
+}
+
 
 fileprivate extension UIImage {
     /// 元の画像に指定されたシャドウを描画して imageWithShadow を返す
@@ -275,6 +379,13 @@ fileprivate extension UIImage {
             cgContext.scaleBy(x: scale, y: scale)
             self.draw(at: .zero)
         }
+    }
+}
+
+private extension UIFont {
+    func bold() -> UIFont {
+        guard let descriptor = fontDescriptor.withSymbolicTraits(.traitBold) else { return self }
+        return UIFont(descriptor: descriptor, size: pointSize)
     }
 }
 
@@ -353,6 +464,9 @@ class MapCoordinator<Parent: MapViewRepresentable>: NSObject, MKMapViewDelegate 
         if annotation is MKUserLocation {
             return nil
         }
+        if let districtAnnotation = annotation as? DistrictAreaLabelAnnotation {
+            return DistrictAreaLabelAnnotationView.view(for: mapView, annotation: districtAnnotation)
+        }
         if let pointAnnotation = annotation as? PointAnnotation {
             return PointAnnotationView.view(for: mapView, annotation: pointAnnotation)
         }
@@ -370,6 +484,9 @@ class MapCoordinator<Parent: MapViewRepresentable>: NSObject, MKMapViewDelegate 
     }
     
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if let polygon = overlay as? DistrictPolygonOverlay {
+            return polygon.renderer()
+        }
         if let polyline = overlay as? PathPolyline {
             return polyline.renderer()
         }

--- a/iOSApp/Sources/Presentation/Parts/Map/MapView.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/MapView.swift
@@ -20,20 +20,24 @@ struct MapView: UIViewRepresentable {
     let style: Style
     let points: [PointEntry]
     let polyline: [Coordinate]
+    let districtAreaOverlays: [DistrictAreaOverlay]
     let floats: [FloatEntry]
     let floatAnnotation: FloatAnnotation?
+    let showsDistrictAreaOverlay: Bool
     @Binding var region: MKCoordinateRegion
     @Binding var size: CGSize?
     let pointTapped: (PointEntry)->Void
     let floatTapped: (FloatEntry)->Void
     let onLongPress: (Coordinate) -> Void
     
-    private init(style: Style, points: [PointEntry], polyline: [Coordinate], floats: [FloatEntry] = [], floatAnnotation: FloatAnnotation? = nil, region: Binding<MKCoordinateRegion>, size: Binding<CGSize?>, pointTapped: @escaping (PointEntry) -> Void, floatTapped: @escaping (FloatEntry) -> Void, onLongPress: @escaping (Coordinate) -> Void) {
+    private init(style: Style, points: [PointEntry], polyline: [Coordinate], districtAreaOverlays: [DistrictAreaOverlay] = [], floats: [FloatEntry] = [], floatAnnotation: FloatAnnotation? = nil, showsDistrictAreaOverlay: Bool = false, region: Binding<MKCoordinateRegion>, size: Binding<CGSize?>, pointTapped: @escaping (PointEntry) -> Void, floatTapped: @escaping (FloatEntry) -> Void, onLongPress: @escaping (Coordinate) -> Void) {
         self.style = style
         self.points = points
         self.polyline = polyline
+        self.districtAreaOverlays = districtAreaOverlays
         self.floats = floats
         self.floatAnnotation = floatAnnotation
+        self.showsDistrictAreaOverlay = showsDistrictAreaOverlay
         self._size = size
         self._region = region
         self.pointTapped = pointTapped
@@ -44,6 +48,8 @@ struct MapView: UIViewRepresentable {
     init(
         style: Style,
         points: [PointEntry] = [],
+        districtAreaOverlays: [DistrictAreaOverlay] = [],
+        showsDistrictAreaOverlay: Bool = false,
         floatAnnotation: FloatAnnotation? = nil,
         region: Binding<MKCoordinateRegion>,
         size: Binding<CGSize?> = .constant(nil),
@@ -51,20 +57,22 @@ struct MapView: UIViewRepresentable {
         floatTapped: @escaping (FloatEntry) -> Void = { _ in },
         onLongPress: @escaping (Coordinate) -> Void = { _ in }
     ) {
-        self.init(style: style, points: points, polyline: points.map(\.coordinate), floatAnnotation: floatAnnotation, region: region, size: size, pointTapped: pointTapped, floatTapped: floatTapped, onLongPress: onLongPress)
+        self.init(style: style, points: points, polyline: points.map(\.coordinate), districtAreaOverlays: districtAreaOverlays, floatAnnotation: floatAnnotation, showsDistrictAreaOverlay: showsDistrictAreaOverlay, region: region, size: size, pointTapped: pointTapped, floatTapped: floatTapped, onLongPress: onLongPress)
     }
     
     init(
         style: Style,
         points: [PointEntry] = [],
         floats: [FloatEntry],
+        districtAreaOverlays: [DistrictAreaOverlay] = [],
+        showsDistrictAreaOverlay: Bool = false,
         region: Binding<MKCoordinateRegion>,
         size: Binding<CGSize?> = .constant(nil),
         pointTapped: @escaping (PointEntry) -> Void = { _ in },
         floatTapped: @escaping (FloatEntry) -> Void = { _ in },
         onLongPress: @escaping (Coordinate) -> Void = { _ in }
     ) {
-        self.init(style: style, points: points, polyline: points.map(\.coordinate), floats: floats, region: region, size: size, pointTapped: pointTapped, floatTapped: floatTapped, onLongPress: onLongPress)
+        self.init(style: style, points: points, polyline: points.map(\.coordinate), districtAreaOverlays: districtAreaOverlays, floats: floats, showsDistrictAreaOverlay: showsDistrictAreaOverlay, region: region, size: size, pointTapped: pointTapped, floatTapped: floatTapped, onLongPress: onLongPress)
     }
    
     
@@ -87,6 +95,11 @@ struct MapView: UIViewRepresentable {
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
+        if showsDistrictAreaOverlay {
+            mapView.updateDistrictAreaOverlays(districtAreaOverlays)
+        } else {
+            mapView.removeDistrictAreaOverlays()
+        }
         mapView.updatePoints(from: points.filter(style: style))
         // ポリラインを isBoundary で分割し、色を交互に設定
         let segments: [[Coordinate]] = splitPoints()
@@ -160,6 +173,9 @@ struct MapView: UIViewRepresentable {
             if annotation is MKUserLocation {
                 return nil
             }
+            if let districtAnnotation = annotation as? DistrictAreaLabelAnnotation {
+                return DistrictAreaLabelAnnotationView.view(for: mapView, annotation: districtAnnotation)
+            }
             if let pointAnnotation = annotation as? PointAnnotation {
                 return PointAnnotationView.view(for: mapView, annotation: pointAnnotation)
             }
@@ -183,6 +199,9 @@ struct MapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let polygon = overlay as? DistrictPolygonOverlay {
+                return polygon.renderer()
+            }
             if let polyline = overlay as? PathPolyline {
                 return polyline.renderer()
             }
@@ -248,6 +267,19 @@ fileprivate extension MKMapView {
         addOverlays(polylines)
         removeOverlays(oldPolylines)
     }
+
+    func updateDistrictAreaOverlays(_ districtAreaOverlays: [DistrictAreaOverlay]) {
+        removeDistrictAreaOverlays()
+        addOverlays(districtAreaOverlays.map(DistrictPolygonOverlay.init))
+        addAnnotations(districtAreaOverlays.map(DistrictAreaLabelAnnotation.init))
+    }
+
+    func removeDistrictAreaOverlays() {
+        let oldPolygons = overlays.compactMap { $0 as? DistrictPolygonOverlay }
+        let oldLabels = annotations.compactMap { $0 as? DistrictAreaLabelAnnotation }
+        removeOverlays(oldPolygons)
+        removeAnnotations(oldLabels)
+    }
     
     func removeFloats() {
         let old = annotations.compactMap { $0 as? FloatAnnotation }
@@ -291,8 +323,10 @@ extension MapView: Equatable {
         return lhs.style == rhs.style &&
         lhs.points == rhs.points &&
         lhs.polyline == rhs.polyline &&
+        lhs.districtAreaOverlays == rhs.districtAreaOverlays &&
         lhs.floats == rhs.floats &&
         lhs.floatAnnotation == rhs.floatAnnotation &&
+        lhs.showsDistrictAreaOverlay == rhs.showsDistrictAreaOverlay &&
         lhs.region == rhs.region
     }
 }

--- a/iOSApp/Sources/Presentation/Parts/Map/MapView.swift
+++ b/iOSApp/Sources/Presentation/Parts/Map/MapView.swift
@@ -95,11 +95,11 @@ struct MapView: UIViewRepresentable {
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        if showsDistrictAreaOverlay {
-            mapView.updateDistrictAreaOverlays(districtAreaOverlays)
-        } else {
-            mapView.removeDistrictAreaOverlays()
-        }
+        context.coordinator.updateDistrictAreaOverlays(
+            districtAreaOverlays,
+            isVisible: showsDistrictAreaOverlay,
+            in: mapView
+        )
         mapView.updatePoints(from: points.filter(style: style))
         // ポリラインを isBoundary で分割し、色を交互に設定
         let segments: [[Coordinate]] = splitPoints()
@@ -163,6 +163,8 @@ struct MapView: UIViewRepresentable {
 
     class Coordinator: NSObject, MKMapViewDelegate {
         var parent: MapView
+        private var renderedDistrictAreaOverlays: Set<DistrictAreaOverlay> = []
+        private var isDistrictAreaOverlayVisible = false
         
         init(_ parent: MapView) {
             self.parent = parent
@@ -219,6 +221,38 @@ struct MapView: UIViewRepresentable {
             let coordinate = mapView.convert(location, toCoordinateFrom: mapView)
             parent.onLongPress(Coordinate.fromCL(coordinate))
         }
+
+        func updateDistrictAreaOverlays(
+            _ districtAreaOverlays: [DistrictAreaOverlay],
+            isVisible: Bool,
+            in mapView: MKMapView
+        ) {
+            let newOverlays = Set(districtAreaOverlays)
+
+            guard isVisible != isDistrictAreaOverlayVisible || newOverlays != renderedDistrictAreaOverlays else {
+                return
+            }
+
+            if !isVisible {
+                removeDistrictAreaOverlays(in: mapView)
+                renderedDistrictAreaOverlays = []
+                isDistrictAreaOverlayVisible = false
+                return
+            }
+
+            removeDistrictAreaOverlays(in: mapView)
+            mapView.addOverlays(districtAreaOverlays.map(DistrictPolygonOverlay.init))
+            mapView.addAnnotations(districtAreaOverlays.map(DistrictAreaLabelAnnotation.init))
+            renderedDistrictAreaOverlays = newOverlays
+            isDistrictAreaOverlayVisible = true
+        }
+
+        private func removeDistrictAreaOverlays(in mapView: MKMapView) {
+            let oldPolygons = mapView.overlays.compactMap { $0 as? DistrictPolygonOverlay }
+            let oldLabels = mapView.annotations.compactMap { $0 as? DistrictAreaLabelAnnotation }
+            mapView.removeOverlays(oldPolygons)
+            mapView.removeAnnotations(oldLabels)
+        }
     }
 }
 
@@ -268,19 +302,6 @@ fileprivate extension MKMapView {
         removeOverlays(oldPolylines)
     }
 
-    func updateDistrictAreaOverlays(_ districtAreaOverlays: [DistrictAreaOverlay]) {
-        removeDistrictAreaOverlays()
-        addOverlays(districtAreaOverlays.map(DistrictPolygonOverlay.init))
-        addAnnotations(districtAreaOverlays.map(DistrictAreaLabelAnnotation.init))
-    }
-
-    func removeDistrictAreaOverlays() {
-        let oldPolygons = overlays.compactMap { $0 as? DistrictPolygonOverlay }
-        let oldLabels = annotations.compactMap { $0 as? DistrictAreaLabelAnnotation }
-        removeOverlays(oldPolygons)
-        removeAnnotations(oldLabels)
-    }
-    
     func removeFloats() {
         let old = annotations.compactMap { $0 as? FloatAnnotation }
         removeAnnotations(old)

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditFeature.swift
@@ -59,6 +59,8 @@ struct RouteEditFeature{
         var isLoading: Bool = false
         var isSubmitDialogPresented: Bool = false
         var tab: Tab
+        var districtAreaOverlays: [DistrictAreaOverlay]
+        var isDistrictAreaOverlayVisible: Bool = false
         var passageInsertIndex: Int? = nil
         var region: MKCoordinateRegion
         var size: CGSize?
@@ -75,6 +77,7 @@ struct RouteEditFeature{
         case onAppear
         case mapLongPressed(Coordinate)
         case pointTapped(PointEntry)
+        case districtAreaOverlayTapped
         case autoPassageTapped
         case undoTapped
         case redoTapped
@@ -133,6 +136,10 @@ struct RouteEditFeature{
             case .pointTapped(let entry):
                 state.point = PointEditFeature.State(entry.point, districtId: state.district.id)
                 state.operation = .add
+                return .none
+            case .districtAreaOverlayTapped:
+                guard state.canShowDistrictAreaOverlay else { return .none }
+                state.isDistrictAreaOverlayVisible.toggle()
                 return .none
             case .autoPassageTapped:
                 let districts: [District] = FetchAll(festivalId: state.district.festivalId).wrappedValue
@@ -340,6 +347,7 @@ extension RouteEditFeature.State {
     var isDeleteable: Bool { mode == .update}
     var isPartialEnable: Bool { tab != .info }
     var isAutoPassageDisabled: Bool { points.count < 2 }
+    var canShowDistrictAreaOverlay: Bool { mode == .preview && !districtAreaOverlays.isEmpty }
     var saveButtonTitle: String {
         switch mode {
         case .preview:
@@ -399,6 +407,9 @@ extension RouteEditFeature.State {
         self._district = districtQuery
         self._period = periodQuery
         self._festival = festivalQuery
+        self.districtAreaOverlays = assignDistrictAreaOverlays(
+            districts: FetchAll(festivalId: districtQuery.wrappedValue.festivalId).wrappedValue
+        )
         
         let origin: Coordinate = districtQuery.wrappedValue.base ?? festivalQuery.wrappedValue.base
 

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
@@ -30,12 +30,16 @@ struct RouteEditView: View {
             }
         }
         .safeAreaInset(edge: .bottom){
-            if #available(iOS 26.0, *), isLiquidGlassEnabled {
-                districtAreaOverlayButton
-                    .glassEffect()
-            } else {
-                districtAreaOverlayButton
+            Group {
+                if #available(iOS 26.0, *), isLiquidGlassEnabled {
+                    districtAreaOverlayButton
+                        .glassEffect()
+                } else {
+                    districtAreaOverlayButton
+                }
             }
+            .padding(.horizontal)
+            .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .toolbar {
             toolbar
@@ -372,7 +376,7 @@ extension RouteEditView {
         } label: {
             Image(systemName: "square.grid.3x3.fill")
                 .padding()
-                .foregroundStyle(isActive ? Color.white : Color(uiColor: .darkGray))
+                .foregroundStyle(isActive ? Color.accent : Color.primary)
         }
         .accessibilityLabel("町域オーバーレイ")
     }

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
@@ -282,14 +282,24 @@ extension RouteEditView {
     
     @ViewBuilder
     var map: some View {
-        MapView(
-            style: store.tab == .public ? .public : .edit,
-            points: store.pointEntries,
-            region: $store.region,
-            size: $store.size,
-            pointTapped: { store.send(.pointTapped($0)) },
-            onLongPress: { store.send(.mapLongPressed($0)) },
-        )
+        ZStack(alignment: .bottomTrailing) {
+            MapView(
+                style: store.tab == .public ? .public : .edit,
+                points: store.pointEntries,
+                districtAreaOverlays: store.districtAreaOverlays,
+                showsDistrictAreaOverlay: store.isDistrictAreaOverlayVisible,
+                region: $store.region,
+                size: $store.size,
+                pointTapped: { store.send(.pointTapped($0)) },
+                onLongPress: { store.send(.mapLongPressed($0)) }
+            )
+
+            if store.canShowDistrictAreaOverlay {
+                districtAreaOverlayButton
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 16)
+            }
+        }
     }
     
     @ViewBuilder
@@ -352,6 +362,29 @@ extension RouteEditView {
             }
             .disabled(!store.isPartialEnable)
         }
+    }
+
+    @ViewBuilder
+    var districtAreaOverlayButton: some View {
+        let isActive = store.isDistrictAreaOverlayVisible
+        Button {
+            store.send(.districtAreaOverlayTapped)
+        } label: {
+            Image(systemName: "square.grid.3x3.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(isActive ? Color.white : Color(uiColor: .darkGray))
+                .frame(width: 48, height: 48)
+                .background(
+                    Circle()
+                        .fill(isActive ? Color(uiColor: .darkGray) : .white)
+                )
+                .overlay(
+                    Circle()
+                        .stroke(Color(uiColor: isActive ? .darkGray : .systemGray4), lineWidth: 1)
+                )
+        }
+        .shadow(color: .black.opacity(0.18), radius: 8, y: 2)
+        .accessibilityLabel("町域オーバーレイ")
     }
     
     @ViewBuilder

--- a/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
+++ b/iOSApp/Sources/Presentation/View/Admin/District/Route/RouteEditView.swift
@@ -29,6 +29,14 @@ struct RouteEditView: View {
                 contentBeforeLiquidGlass
             }
         }
+        .safeAreaInset(edge: .bottom){
+            if #available(iOS 26.0, *), isLiquidGlassEnabled {
+                districtAreaOverlayButton
+                    .glassEffect()
+            } else {
+                districtAreaOverlayButton
+            }
+        }
         .toolbar {
             toolbar
         }
@@ -282,24 +290,16 @@ extension RouteEditView {
     
     @ViewBuilder
     var map: some View {
-        ZStack(alignment: .bottomTrailing) {
-            MapView(
-                style: store.tab == .public ? .public : .edit,
-                points: store.pointEntries,
-                districtAreaOverlays: store.districtAreaOverlays,
-                showsDistrictAreaOverlay: store.isDistrictAreaOverlayVisible,
-                region: $store.region,
-                size: $store.size,
-                pointTapped: { store.send(.pointTapped($0)) },
-                onLongPress: { store.send(.mapLongPressed($0)) }
-            )
-
-            if store.canShowDistrictAreaOverlay {
-                districtAreaOverlayButton
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 16)
-            }
-        }
+        MapView(
+            style: store.tab == .public ? .public : .edit,
+            points: store.pointEntries,
+            districtAreaOverlays: store.districtAreaOverlays,
+            showsDistrictAreaOverlay: store.isDistrictAreaOverlayVisible,
+            region: $store.region,
+            size: $store.size,
+            pointTapped: { store.send(.pointTapped($0)) },
+            onLongPress: { store.send(.mapLongPressed($0)) }
+        )
     }
     
     @ViewBuilder
@@ -371,19 +371,9 @@ extension RouteEditView {
             store.send(.districtAreaOverlayTapped)
         } label: {
             Image(systemName: "square.grid.3x3.fill")
-                .font(.system(size: 18, weight: .semibold))
+                .padding()
                 .foregroundStyle(isActive ? Color.white : Color(uiColor: .darkGray))
-                .frame(width: 48, height: 48)
-                .background(
-                    Circle()
-                        .fill(isActive ? Color(uiColor: .darkGray) : .white)
-                )
-                .overlay(
-                    Circle()
-                        .stroke(Color(uiColor: isActive ? .darkGray : .systemGray4), lineWidth: 1)
-                )
         }
-        .shadow(color: .black.opacity(0.18), radius: 8, y: 2)
         .accessibilityLabel("町域オーバーレイ")
     }
     


### PR DESCRIPTION
## 目的\nルート確認画面の地図上に、町域オーバーレイを iOS 側へ移植する。\n\n## 変更点\n- 町域ポリゴンとラベルを MapKit の overlay / annotation として描画\n- 地図移動時に毎回再描画しないよう、overlay の更新を state 差分ベースに変更\n- 既存のクラッシュ要因だった polygon 実装を修正\n\n## 動作確認\n- Command line invocation:
    /Applications/Xcode-26.5.0-Release.Candidate.app/Contents/Developer/usr/bin/xcodebuild -project iOSApp/MaTool.xcodeproj -scheme iOSApp -destination "generic/platform=iOS Simulator" build

Resolve Package Graph
You don’t have permission to save the file “repositories” in the folder “SourcePackages”. 成功\n\n## リスク\n- Simulator 起動確認はこの環境の CoreSimulatorService 問題で未実施