### PR TITLE
ios: 行動表の長文表示を折り返し対応

### DIFF
--- a/iOSApp/Sources/Presentation/Utils/PDFRenderer.swift
+++ b/iOSApp/Sources/Presentation/Utils/PDFRenderer.swift
@@ -81,6 +81,11 @@ struct ActionTableLineLayout {
 }
 
 enum ActionTableTextFitter {
+    struct Layout {
+        let fontSize: CGFloat
+        let shouldWrap: Bool
+    }
+
     static func fontSize(
         for text: String,
         maxFontSize: CGFloat,
@@ -99,6 +104,27 @@ enum ActionTableTextFitter {
         }
 
         return minFontSize
+    }
+
+    static func layout(
+        for text: String,
+        maxFontSize: CGFloat,
+        minFontSize: CGFloat,
+        width: CGFloat,
+        height: CGFloat,
+        weight: UIFont.Weight = .medium
+    ) -> Layout {
+        let fittedFontSize = fontSize(
+            for: text,
+            maxFontSize: maxFontSize,
+            minFontSize: minFontSize,
+            width: width,
+            weight: weight
+        )
+        let font = UIFont.systemFont(ofSize: fittedFontSize, weight: weight)
+        let measuredWidth = (text as NSString).size(withAttributes: [.font: font]).width
+        let shouldWrap = measuredWidth > width && height >= (font.lineHeight * 2)
+        return Layout(fontSize: fittedFontSize, shouldWrap: shouldWrap)
     }
 }
 
@@ -261,13 +287,19 @@ struct ActionTableSnapshotter: Sendable {
             let entryIndex = baseIndex + column
             guard entryIndex < entries.count else { continue }
             let cellRect = layout.textRects[column]
-            let fontSize = ActionTableTextFitter.fontSize(
+            let textLayout = ActionTableTextFitter.layout(
                 for: entries[entryIndex],
                 maxFontSize: rowFontSize,
                 minFontSize: minimumRowFontSize,
-                width: max(cellRect.width - 8, 0)
+                width: max(cellRect.width - 8, 0),
+                height: max(cellRect.height - 4, 0)
             )
-            drawCenteredText(entries[entryIndex], in: cellRect, fontSize: fontSize)
+            drawCenteredText(
+                entries[entryIndex],
+                in: cellRect,
+                fontSize: textLayout.fontSize,
+                wraps: textLayout.shouldWrap
+            )
         }
     }
 
@@ -286,19 +318,47 @@ struct ActionTableSnapshotter: Sendable {
         }
     }
 
-    private func drawCenteredText(_ text: String, in rect: CGRect, fontSize: CGFloat) {
+    private func drawCenteredText(_ text: String, in rect: CGRect, fontSize: CGFloat, wraps: Bool = false) {
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
-        paragraph.lineBreakMode = .byTruncatingTail
+        paragraph.lineBreakMode = wraps ? .byCharWrapping : .byTruncatingTail
         let attrs: [NSAttributedString.Key: Any] = [
             .font: UIFont.systemFont(ofSize: fontSize, weight: .medium),
             .foregroundColor: UIColor.black,
             .paragraphStyle: paragraph
         ]
-        let drawRect = CGRect(
+        let availableRect = CGRect(
             x: rect.minX + 4,
-            y: rect.midY - (fontSize + 8) / 2,
+            y: rect.minY + 2,
             width: rect.width - 8,
+            height: rect.height - 4
+        )
+        if wraps {
+            let boundingRect = (text as NSString).boundingRect(
+                with: availableRect.size,
+                options: [.usesLineFragmentOrigin, .usesFontLeading],
+                attributes: attrs,
+                context: nil
+            )
+            let drawRect = CGRect(
+                x: availableRect.minX,
+                y: availableRect.midY - min(boundingRect.height, availableRect.height) / 2,
+                width: availableRect.width,
+                height: availableRect.height
+            )
+            (text as NSString).draw(
+                with: drawRect,
+                options: [.usesLineFragmentOrigin, .usesFontLeading],
+                attributes: attrs,
+                context: nil
+            )
+            return
+        }
+
+        let drawRect = CGRect(
+            x: availableRect.minX,
+            y: rect.midY - (fontSize + 8) / 2,
+            width: availableRect.width,
             height: fontSize + 10
         )
         (text as NSString).draw(in: drawRect, withAttributes: attrs)

--- a/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
+++ b/iOSApp/Tests/Presentation/Utils/PDFRendererTests.swift
@@ -38,6 +38,19 @@ struct PDFRendererTests {
         #expect(longFontSize >= 9)
     }
 
+    @Test func 行動表文字は最小フォントでも収まらない場合に折り返す() {
+        let layout = ActionTableTextFitter.layout(
+            for: "とても長いRoutePassageの説明テキスト",
+            maxFontSize: 15,
+            minFontSize: 9,
+            width: 40,
+            height: 24
+        )
+
+        #expect(layout.fontSize == 9)
+        #expect(layout.shouldWrap)
+    }
+
     @Test @MainActor func 行動表は自町の通過町を自町と表示する() {
         let district = District(id: "district-1", name: "中央町", festivalId: "festival-1")
         let route = Route(id: "route-1", districtId: district.id, periodId: "period-1")


### PR DESCRIPTION
## 目的
行動表で文字サイズを最小まで縮小しても収まらないケースがあり、表示が欠けることがあったため対応します。

## 変更点
- 行動表セルの文字に対して、最小フォントでも横幅に収まらない場合は折り返し表示に切り替える処理を追加
- 既存の縮小ロジックは維持し、通常は1行表示のままにする
- 折り返し判定のテストを追加

## 動作確認
- ActionTableTextFitter.layout のテストを追加
- iOSAppTests の実行を開始し、依存解決とビルド開始までは確認
- 依存パッケージの初回ビルドが重く、このターン内では完走確認までは未実施

## 影響範囲・リスク
- 行動表PDFのセル内文字描画に限定した変更です
- セル高さが極端に小さい場合は、2行でも完全には収まらない可能性があります